### PR TITLE
Downscale management scenarios to field scale

### DIFF
--- a/000-config.R
+++ b/000-config.R
@@ -13,7 +13,7 @@ PRODUCTION <- args$production
 
 # Manual override for interactive sessions
 if (rlang::is_interactive()) {
-  PRODUCTION <- TRUE
+  PRODUCTION <- FALSE  # change this (just for testing)
 }
 
 ## Set parallel processing options
@@ -27,6 +27,27 @@ if (ccmmf_dir == "") {
   ccmmf_dir <- "/projectnb2/dietzelab/ccmmf"
 }
 pecan_outdir <- file.path(ccmmf_dir, "modelout", "ccmmf_phase_2b_mixed_pfts_20250701")
+
+# -----Management scenarios config -----
+# set to TRUE to use Phase 3 management scenario outputs
+USE_PHASE_3_SCENARIOS <- TRUE
+
+phase_3_outdir <- file.path(ccmmf_dir, "modelout", "ccmmf_phase_3_scenarios_20251210")
+
+management_scenarios <- c(
+  "baseline",
+  "compost",
+  "reduced_till",
+  "zero_till",
+  "reduced_irrig_drip",
+  "stacked"
+)
+
+model_outdir <- file.path(pecan_outdir, "out")
+# override paths if using Phase 3
+if (USE_PHASE_3_SCENARIOS) {
+  pecan_outdir <- phase_3_outdir
+}
 
 # **Variables to extract**
 # see docs/workflow_documentation.qmd for complete list of outputs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,20 +6,31 @@ Once a new release is made this file will be updated to create a new `Unreleased
 
 For more information about this file see also [Keep a Changelog](http://keepachangelog.com/) .
 
-<!-- 
+
 sections to include in release notes:
 
 ## [Unreleased]
 
 ### Added
 
+- Management scenario support for comparing agricultural practices
+  - Configuration flag `USE_PHASE_3_SCENARIOS` in `000-config.R`
+  - Six scenarios: baseline, compost, reduced_till, zero_till, reduced_irrig_drip, stacked
+  - Scenario-aware extraction from pre-aggregated `.Rdata` files
+  - `scenario` column added to all output CSVs
+  - `scenarios` array in metadata JSON
+- Early exit in `031_aggregate_sipnet_output.R` for single-PFT runs
+- Parquet output for large files (>100k rows) via `write_output()` helper
+
 ### Fixed
+
+- Empty vector handling in mixed-scenario logic (`040_downscale.R`)
 
 ### Changed
 
 ### Removed
 
--->
+
 
 ## 0.2.0-2a
 

--- a/scripts/030_extract_sipnet_output.R
+++ b/scripts/030_extract_sipnet_output.R
@@ -91,7 +91,6 @@ if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
 } else {
     
     #----------NetCDF extraction-------------------------------
-    PEcAn.logger::logger.info("Phase 2 mode: Extracting from NetCDF files")
     
     # Read settings file and extract run information
     settings <- PEcAn.settings::read.settings(file.path(pecan_outdir, "pecan.CONFIGS.xml"))

--- a/scripts/030_extract_sipnet_output.R
+++ b/scripts/030_extract_sipnet_output.R
@@ -15,187 +15,268 @@
 ## Second, make sure ccmmf_dir and pecan_outdir are defined in the config file
 source("000-config.R")
 PEcAn.logger::logger.info("***Starting SIPNET output extraction***")
-# Read settings file and extract run information
-settings <- PEcAn.settings::read.settings(file.path(pecan_outdir, "pecan.CONFIGS.xml"))
 
-ensemble_size <- settings$ensemble$size |>
-    as.numeric()
-start_date <- settings$run$settings.1$start.date
-start_year <- lubridate::year(start_date)
-end_date <- settings$run$settings.1$end.date
-end_year <- lubridate::year(end_date)
-
-
-design_points_csv <- "https://raw.githubusercontent.com/ccmmf/workflows/refs/tags/v0.2.0/data/design_points.csv"
-design_points <- readr::read_csv(design_points_csv)
-
-# Read the runs.txt file to get ensemble and site and directory information
-runs_file <- file.path(pecan_outdir, "run", "runs.txt")
-## Expected outputs based on runs.txt
-expected_ens_dirs <- tibble::tibble(
-    dir = readr::read_lines(runs_file)
-) |>
-    tidyr::separate(
-        col = "dir",
-        into = c("prefix", "ens", "site_id"),
-        sep = "-",
-        remove = FALSE
-    ) |>
-    dplyr::mutate(
-        # base ID has no suffix; used to match design_points
-        base_site_id = sub("_grass$", "", site_id),
-        # PFT determined by presence of the suffix in the actual site_id
-        pft = dplyr::if_else(
-            grepl("_grass$", site_id),
-            "annual crop",
-            "woody perennial crop"
-        )
-    ) |>
-    dplyr::select(-prefix)
-
-## Check that all expected are present
-actual_ens_dirs <- dir(model_outdir)
-dirs_present <- all(expected_ens_dirs$dir %in% actual_ens_dirs)
-if (!dirs_present) {
-    missing_dirs <- setdiff(expected_ens_dirs$dir, actual_ens_dirs)
-    PEcAn.logger::logger.severe(
-        "Not all expected ensemble directories are present in the model output directory.",
-        "Missing: ", paste(missing_dirs, collapse = ", ")
+#----------Management scenario extraction-------------------------------
+# TODO: extend to support multi-PFT scenarios when woody crop management scenarios are added
+if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
+    PEcAn.logger::logger.info("Loading pre-extracted scenario data")
+    
+    rdata_files <- list.files(
+        pecan_outdir,
+        pattern = "^results_monthly_.*\\.Rdata$",
+        full.names = TRUE
     )
-}
-ens_dirs <- expected_ens_dirs
-
-# Map each actual site_id (with/without suffix) to lat/lon via base_site_id
-site_meta <- ens_dirs |>
-    dplyr::distinct(site_id, base_site_id, pft) |>
-    dplyr::left_join(
-        design_points |> dplyr::select(site_id, lat, lon),
-        by = dplyr::join_by(base_site_id == site_id)
-    )
-
-site_ids <- site_meta |>
-    dplyr::pull(site_id) |>
-    unique()
-
-ens_ids <- 1:ensemble_size
-
-variables <- outputs_to_extract # TODO standardize this name; variables is ambiguous
-                                # but is used by the PEcAn read.output function
-
-if (!PRODUCTION) {
-    ## -----TESTING SUBSET----##
-    site_ids <- site_ids[1:10]
-    ens_ids <- ens_ids[1:10]
-    start_year <- end_year - 1
-}
-
-## Create dataframe of directories to process, filtered to include only
-##   existing directories (ens_dirs) that have site_ids and ensemble IDs
-ens_ids_str <- PEcAn.utils::left.pad.zeros(ens_ids)
-dirs_to_process <- ens_dirs |>
-    dplyr::filter(
-        site_id %in% site_ids,
-        ens %in% ens_ids_str
-    )
-
-ens_dirs_subset <- ens_dirs |>
-    dplyr::filter(
-        base_site_id %in% site_ids, # use base_site_id (site_id may include _grass)
-        as.numeric(ens) %in% ens_ids
-    ) |>
-    dplyr::mutate(dir = file.path(model_outdir, dir)) |>
-    dplyr::select(ens, site_id, dir, pft, base_site_id) # keep both ids
-
-# extract output via PEcAn.utils::read.output
-# temporarily suppress logging or else it will print a lot of file names
-logger_level <- PEcAn.logger::logger.setLevel("OFF")
-ens_results_raw <- furrr::future_pmap_dfr(
-    ens_dirs_subset,
-    function(ens, site_id, dir, pft, base_site_id) {
-        out_df <- PEcAn.utils::read.output(
-            runid = paste(ens, site_id, sep = "-"),
-            outdir = dir,
-            start.year = start_year,
-            end.year = end_year,
-            variables = variables,
-            dataframe = TRUE,
-            verbose = FALSE
-        ) |>
-            dplyr::mutate(
-                site_id = .env$site_id,
-                parameter = as.numeric(.env$ens),
-                pft = .env$pft,
-                base_site_id = .env$base_site_id
+    
+    if (length(rdata_files) == 0) {
+        PEcAn.logger::logger.severe("No pre-extracted .Rdata files found in ", pecan_outdir)
+    }
+    
+    # load site info for lat/lon
+    site_info <- readr::read_csv(file.path(pecan_outdir, "site_info.csv"))
+    
+    # process each variable file
+    all_results <- list()
+    for (rdata_file in rdata_files) {
+        var_name <- stringr::str_extract(basename(rdata_file), "(?<=results_monthly_)[^.]+")
+        
+        if (!var_name %in% outputs_to_extract) {
+            PEcAn.logger::logger.info("Skipping ", var_name, " (not in outputs_to_extract)")
+            next
+        }
+        
+        PEcAn.logger::logger.info("Loading ", var_name, " from ", basename(rdata_file))
+        load(rdata_file)  # loads 'results' dataframe
+        
+        # convert to EFI format
+        var_results <- results |>
+            dplyr::rename(
+                site_id = site,
+                parameter = ens_num,
+                datetime = posix
             ) |>
-            dplyr::rename(time = posix)
-    },
-    # Avoids warning "future unexpectedly generated random numbers",
-    # .Bug report: https://github.com/r-quantities/units/issues/409
-    # Fixed in units version >= 0.8.7
-    .options = furrr::furrr_options(seed = TRUE)
-) 
-
-ens_results <- ens_results_raw |>
-    dplyr::group_by(parameter, base_site_id, pft, year) |>
-    dplyr::ungroup() |>
-    dplyr::arrange(parameter, base_site_id, pft, year) |>
-    tidyr::pivot_longer(
-        cols = tidyr::all_of(variables),
-        names_to = "variable",
-        values_to = "prediction"
+            dplyr::left_join(
+                site_info |> dplyr::select(id, lat, lon),
+                by = c("site_id" = "id")
+            ) |>
+            tidyr::pivot_longer(
+                cols = tidyr::all_of(var_name),
+                names_to = "variable",
+                values_to = "prediction"
+            ) |>
+            dplyr::mutate(
+                pft = "annual crop",
+                datetime = lubridate::floor_date(datetime, unit = "month"),
+                variable_type = "pool"
+            ) |>
+            dplyr::group_by(scenario, datetime, site_id, lat, lon, pft, parameter, variable, variable_type) |>
+            dplyr::summarise(prediction = mean(prediction, na.rm = TRUE), .groups = "drop")
+        
+        all_results[[var_name]] <- var_results
+    }
+    
+    ens_results <- dplyr::bind_rows(all_results)
+    
+    # write output
+    ensemble_output_csv <- file.path(model_outdir, "ensemble_output.csv")
+    readr::write_csv(ens_results, ensemble_output_csv)
+    PEcAn.logger::logger.info(
+        "\nPhase 3 extraction complete.",
+        "\nScenarios: ", paste(unique(ens_results$scenario), collapse = ", "),
+        "\nSites: ", dplyr::n_distinct(ens_results$site_id),
+        "\nEnsembles: ", dplyr::n_distinct(ens_results$parameter),
+        "\nVariables: ", paste(unique(ens_results$variable), collapse = ", "),
+        "\nSaved to: ", ensemble_output_csv
+    )
+    
+} else {
+    
+    #----------NetCDF extraction-------------------------------
+    PEcAn.logger::logger.info("Phase 2 mode: Extracting from NetCDF files")
+    
+    # Read settings file and extract run information
+    settings <- PEcAn.settings::read.settings(file.path(pecan_outdir, "pecan.CONFIGS.xml"))
+    
+    ensemble_size <- settings$ensemble$size |>
+        as.numeric()
+    start_date <- settings$run$settings.1$start.date
+    start_year <- lubridate::year(start_date)
+    end_date <- settings$run$settings.1$end.date
+    end_year <- lubridate::year(end_date)
+    
+    
+    design_points_csv <- "https://raw.githubusercontent.com/ccmmf/workflows/refs/tags/v0.2.0/data/design_points.csv"
+    design_points <- readr::read_csv(design_points_csv)
+    
+    # Read the runs.txt file to get ensemble and site and directory information
+    runs_file <- file.path(pecan_outdir, "run", "runs.txt")
+    ## Expected outputs based on runs.txt
+    expected_ens_dirs <- tibble::tibble(
+        dir = readr::read_lines(runs_file)
     ) |>
-    dplyr::rename(datetime = time) |>
-    dplyr::left_join(site_meta,
-        by = c("site_id", "base_site_id", "pft")
-    ) |>
-    dplyr::select(-site_id) |>
-    dplyr::rename(site_id = base_site_id) |>
-    dplyr::select(datetime, site_id, lat, lon, pft, parameter, variable, prediction)
-
-# Classify variables as 'pool' (state) vs 'flux' (rate) using PEcAn standard_vars.
-std_vars <- PEcAn.utils::standard_vars
-
-pool_vars <- std_vars |>
+        tidyr::separate(
+            col = "dir",
+            into = c("prefix", "ens", "site_id"),
+            sep = "-",
+            remove = FALSE
+        ) |>
+        dplyr::mutate(
+            # base ID has no suffix; used to match design_points
+            base_site_id = sub("_grass$", "", site_id),
+            # PFT determined by presence of the suffix in the actual site_id
+            pft = dplyr::if_else(
+                grepl("_grass$", site_id),
+                "annual crop",
+                "woody perennial crop"
+            )
+        ) |>
+        dplyr::select(-prefix)
+    
+    ## Check that all expected are present
+    actual_ens_dirs <- dir(model_outdir)
+    dirs_present <- all(expected_ens_dirs$dir %in% actual_ens_dirs)
+    if (!dirs_present) {
+        missing_dirs <- setdiff(expected_ens_dirs$dir, actual_ens_dirs)
+        PEcAn.logger::logger.severe(
+            "Not all expected ensemble directories are present in the model output directory.",
+            "Missing: ", paste(missing_dirs, collapse = ", ")
+        )
+    }
+    ens_dirs <- expected_ens_dirs
+    
+    # Map each actual site_id (with/without suffix) to lat/lon via base_site_id
+    site_meta <- ens_dirs |>
+        dplyr::distinct(site_id, base_site_id, pft) |>
+        dplyr::left_join(
+            design_points |> dplyr::select(site_id, lat, lon),
+            by = dplyr::join_by(base_site_id == site_id)
+        )
+    
+    site_ids <- site_meta |>
+        dplyr::pull(site_id) |>
+        unique()
+    
+    ens_ids <- 1:ensemble_size
+    
+    variables <- outputs_to_extract # TODO standardize this name; variables is ambiguous
+                                    # but is used by the PEcAn read.output function
+    
+    if (!PRODUCTION) {
+        ## -----TESTING SUBSET----##
+        site_ids <- site_ids[1:10]
+        ens_ids <- ens_ids[1:10]
+        start_year <- end_year - 1
+    }
+    
+    ## Create dataframe of directories to process, filtered to include only
+    ##   existing directories (ens_dirs) that have site_ids and ensemble IDs
+    ens_ids_str <- PEcAn.utils::left.pad.zeros(ens_ids)
+    dirs_to_process <- ens_dirs |>
+        dplyr::filter(
+            site_id %in% site_ids,
+            ens %in% ens_ids_str
+        )
+    
+    ens_dirs_subset <- ens_dirs |>
+        dplyr::filter(
+            base_site_id %in% site_ids, # use base_site_id (site_id may include _grass)
+            as.numeric(ens) %in% ens_ids
+        ) |>
+        dplyr::mutate(dir = file.path(model_outdir, dir)) |>
+        dplyr::select(ens, site_id, dir, pft, base_site_id) # keep both ids
+    
+    # extract output via PEcAn.utils::read.output
+    # temporarily suppress logging or else it will print a lot of file names
+    logger_level <- PEcAn.logger::logger.setLevel("OFF")
+    ens_results_raw <- furrr::future_pmap_dfr(
+        ens_dirs_subset,
+        function(ens, site_id, dir, pft, base_site_id) {
+            out_df <- PEcAn.utils::read.output(
+                runid = paste(ens, site_id, sep = "-"),
+                outdir = dir,
+                start.year = start_year,
+                end.year = end_year,
+                variables = variables,
+                dataframe = TRUE,
+                verbose = FALSE
+            ) |>
+                dplyr::mutate(
+                    site_id = .env$site_id,
+                    parameter = as.numeric(.env$ens),
+                    pft = .env$pft,
+                    base_site_id = .env$base_site_id
+                ) |>
+                dplyr::rename(time = posix)
+        },
+        # Avoids warning "future unexpectedly generated random numbers",
+        # .Bug report: https://github.com/r-quantities/units/issues/409
+        # Fixed in units version >= 0.8.7
+        .options = furrr::furrr_options(seed = TRUE)
+    ) 
+    
+    ens_results <- ens_results_raw |>
+        dplyr::group_by(parameter, base_site_id, pft, year) |>
+        dplyr::ungroup() |>
+        dplyr::arrange(parameter, base_site_id, pft, year) |>
+        tidyr::pivot_longer(
+            cols = tidyr::all_of(variables),
+            names_to = "variable",
+            values_to = "prediction"
+        ) |>
+        dplyr::rename(datetime = time) |>
+        dplyr::left_join(site_meta,
+            by = c("site_id", "base_site_id", "pft")
+        ) |>
+        dplyr::select(-site_id) |>
+        dplyr::rename(site_id = base_site_id) |>
+        dplyr::mutate(scenario = "baseline") |>  # Add scenario column for consistency
+        dplyr::select(scenario, datetime, site_id, lat, lon, pft, parameter, variable, prediction)
+    
+    # Classify variables as 'pool' (state) vs 'flux' (rate) using PEcAn standard_vars.
+    std_vars <- PEcAn.utils::standard_vars
+    
+    pool_vars <- std_vars |>
         dplyr::filter(stringr::str_detect(tolower(Category), "pool")) |>
         dplyr::pull(Variable.Name) 
-
-flux_vars <- std_vars |>
+    
+    flux_vars <- std_vars |>
         dplyr::filter(stringr::str_detect(tolower(Category), "flux")) |>
         dplyr::pull(Variable.Name)
-
-ens_results <- ens_results |>
-    dplyr::mutate(
-        datetime = lubridate::floor_date(datetime, unit = "month"),
-        variable_type = dplyr::case_when(
-            variable %in% pool_vars ~ "pool",
-            variable %in% flux_vars ~ "flux",
-            TRUE ~ "unknown"
+    
+    ens_results <- ens_results |>
+        dplyr::mutate(
+            datetime = lubridate::floor_date(datetime, unit = "month"),
+            variable_type = dplyr::case_when(
+                variable %in% pool_vars ~ "pool",
+                variable %in% flux_vars ~ "flux",
+                TRUE ~ "unknown"
+            )
+        ) |>
+        dplyr::group_by(scenario, datetime, site_id, lat, lon, pft, parameter, variable, variable_type) |>
+        dplyr::summarise(
+            prediction = mean(prediction, na.rm = TRUE),
+            .groups = "drop"
         )
-    ) |>
-    dplyr::group_by(datetime, site_id, lat, lon, pft, parameter, variable, variable_type) |>
-    dplyr::summarise(
-        prediction = mean(prediction, na.rm = TRUE),
-        .groups = "drop"
+    
+    # Warn if flux variables are present because users may need to treat them differently.
+    if (any(ens_results$variable_type == "flux")) {
+        PEcAn.logger::logger.severe(
+            "Flux variables detected in ensemble output. Note: averaging flux (rate) variables",
+            "across ensembles/sites or over time can be misleading. Consider computing cumulative",
+            "fluxes over simulation period",
+        )
+    }
+    
+    # After extraction, ens_results$prediction is in kg C m-2 for both AGB and TotSoilCarb
+    
+    # restore logging
+    logger_level <- PEcAn.logger::logger.setLevel(logger_level)
+    
+    ensemble_output_csv <- file.path(model_outdir, "ensemble_output.csv")
+    readr::write_csv(ens_results, ensemble_output_csv)
+    PEcAn.logger::logger.info(
+        "\nEnsemble output extraction complete.",
+        "\nResults saved to ", ensemble_output_csv
     )
-
-# Warn if flux variables are present because users may need to treat them differently.
-if (any(ens_results$variable_type == "flux")) {
-    PEcAn.logger::logger.severe(
-        "Flux variables detected in ensemble output. Note: averaging flux (rate) variables",
-        "across ensembles/sites or over time can be misleading. Consider computing cumulative",
-        "fluxes over simulation period",
-    )
+    PEcAn.logger::logger.setLevel(logger_level)
+    
 }
-
-# After extraction, ens_results$prediction is in kg C m-2 for both AGB and TotSoilCarb
-
-# restore logging
-logger_level <- PEcAn.logger::logger.setLevel(logger_level)
- 
-ensemble_output_csv <- file.path(model_outdir, "ensemble_output.csv")
-readr::write_csv(ens_results, ensemble_output_csv)
-PEcAn.logger::logger.info(
-    "\nEnsemble output extraction complete.",
-    "\nResults saved to ", ensemble_output_csv
-)
-PEcAn.logger::logger.setLevel(logger_level)

--- a/scripts/031_aggregate_sipnet_output.R
+++ b/scripts/031_aggregate_sipnet_output.R
@@ -16,6 +16,16 @@
 
 source("000-config.R")
 
+# skip for single-PFT management scenarios (multi-PFT aggregation not applicable)
+# TODO: extend to support multi-PFT management scenarios when woody crop scenarios are added
+if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
+  PEcAn.logger::logger.info(
+    "Skipping multi-PFT aggregation (single PFT scenarios).",
+    "Proceeding directly to 040_downscale.R"
+  )
+  quit(save = "no", status = 0)
+}
+
 PEcAn.logger::logger.info("*** Starting multi-PFT aggregation ***")
 source(here::here("R", "mixed_aggregation.R"))
 


### PR DESCRIPTION
### Summary

Adds support for downscaling multiple management scenarios to field-level carbon estimates. The workflow now processes six agricultural practice scenarios (baseline, compost, reduced_till, zero_till, reduced_irrig_drip, stacked) and generates per-field predictions for annual croplands.

### Motivation

Closes [#167](https://github.com/ccmmf/organization/issues/167)

Comparing carbon outcomes across management practices requires field-scale predictions for each scenario. This enables to evaluate the relative impact of interventions such as compost application, tillage reduction, and drip irrigation on soil organic carbon and aboveground biomass.

### Notes

- Backward compatible: existing multi-PFT workflows (Phase 2) continue to work when `USE_PHASE_3_SCENARIOS = FALSE`