### PR TITLE
Downscale management scenarios to field scale

### DIFF
--- a/000-config.R
+++ b/000-config.R
@@ -13,7 +13,7 @@ PRODUCTION <- args$production
 
 # Manual override for interactive sessions
 if (rlang::is_interactive()) {
-  PRODUCTION <- FALSE  # change this (just for testing)
+  PRODUCTION <- TRUE
 }
 
 ## Set parallel processing options
@@ -50,7 +50,6 @@ management_scenarios <- c(
   "stacked"
 )
 
-model_outdir <- file.path(pecan_outdir, "out")
 # override paths if using Phase 3
 if (USE_PHASE_3_SCENARIOS) {
   pecan_outdir <- phase_3_outdir

--- a/000-config.R
+++ b/000-config.R
@@ -13,7 +13,7 @@ PRODUCTION <- args$production
 
 # Manual override for interactive sessions
 if (rlang::is_interactive()) {
-  PRODUCTION <- TRUE
+  PRODUCTION <- FALSE  # change this (just for testing)
 }
 
 ## Set parallel processing options
@@ -34,6 +34,27 @@ pecan_outdir <- file.path(ccmmf_dir, "modelout", "ccmmf_phase_2b_mixed_pfts_2025
 
 # PEcAn model output to be analyzed
 pecan_archive_tgz <- file.path(ccmmf_dir, "lebauer_agu_2025_20251210.tgz")
+
+# -----Management scenarios config -----
+# set to TRUE to use Phase 3 management scenario outputs
+USE_PHASE_3_SCENARIOS <- TRUE
+
+phase_3_outdir <- file.path(ccmmf_dir, "modelout", "ccmmf_phase_3_scenarios_20251210")
+
+management_scenarios <- c(
+  "baseline",
+  "compost",
+  "reduced_till",
+  "zero_till",
+  "reduced_irrig_drip",
+  "stacked"
+)
+
+model_outdir <- file.path(pecan_outdir, "out")
+# override paths if using Phase 3
+if (USE_PHASE_3_SCENARIOS) {
+  pecan_outdir <- phase_3_outdir
+}
 
 # **Variables to extract**
 # see docs/workflow_documentation.qmd for complete list of outputs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,20 +6,31 @@ Once a new release is made this file will be updated to create a new `Unreleased
 
 For more information about this file see also [Keep a Changelog](http://keepachangelog.com/) .
 
-<!-- 
+
 sections to include in release notes:
 
 ## [Unreleased]
 
 ### Added
 
+- Management scenario support for comparing agricultural practices
+  - Configuration flag `USE_PHASE_3_SCENARIOS` in `000-config.R`
+  - Six scenarios: baseline, compost, reduced_till, zero_till, reduced_irrig_drip, stacked
+  - Scenario-aware extraction from pre-aggregated `.Rdata` files
+  - `scenario` column added to all output CSVs
+  - `scenarios` array in metadata JSON
+- Early exit in `031_aggregate_sipnet_output.R` for single-PFT runs
+- Parquet output for large files (>100k rows) via `write_output()` helper
+
 ### Fixed
+
+- Empty vector handling in mixed-scenario logic (`040_downscale.R`)
 
 ### Changed
 
 ### Removed
 
--->
+
 
 ## 0.2.0-2a
 

--- a/docs/workflow_documentation.md
+++ b/docs/workflow_documentation.md
@@ -75,6 +75,26 @@ git clone git@github.com:ccmmf/downscaling
   - detect and use resources for parallel processing (with future package); default is `available cores - 1`
   - PRODUCTION mode setting. For testing, set `PRODUCTION` to `FALSE`. This is _much_ faster and requires fewer computing resources because it subsets large datasets. Once a test run is successful, set `PRODUCTION` to `TRUE` to run the full workflow.
 
+#### Management Scenario Configuration
+
+To compare carbon outcomes under different agricultural practices, enable management scenario mode:
+```r
+USE_PHASE_3_SCENARIOS <- TRUE
+```
+
+When enabled, the workflow processes multiple management scenarios in a single run. Each scenario represents a different combination of practices applied to annual croplands.
+
+**Available Management Scenarios:**
+
+| Scenario | Description |
+|----------|-------------|
+| baseline | Conventional management practices |
+| compost | Compost application replacing mineral N fertilizer |
+| reduced_till | Reduced tillage intensity (0.10) |
+| zero_till | No tillage (0.00) |
+| reduced_irrig_drip | Drip irrigation replacing canopy irrigation |
+| stacked | Combined: compost + reduced tillage + drip irrigation |
+
 ### 1. Data Preparation
 
 ```sh
@@ -235,9 +255,13 @@ Extracts and formats SIPNET outputs for downscaling:
 
 **Inputs:**
 - `out/ENS-<ensemble_number>-<site_id>/YYYY.nc`
+- `results_monthly_<variable>.Rdata` (management scenario mode)
+- `site_info.csv` (management scenario mode)
 
 **Outputs:**
-- `out/ensemble_output.csv`: Long format data
+- `out/ensemble_output.csv`: Long format data with columns:
+  - `scenario`: Management scenario identifier (when scenarios enabled)
+  - `datetime`, `site_id`, `lat`, `lon`, `pft`, `parameter`, `variable`, `prediction`
 
 ### 5. Mixed Cropping Systems
 
@@ -277,12 +301,13 @@ Builds Random Forest models to predict carbon pools for all fields; aggregates t
 - `data/site_covariates.csv`: Environmental covariates
 
 **Outputs from `040_downscale.R`:**
-- `model_outdir/downscaled_preds.csv`: Per-site, per-ensemble predictions with totals and densities
-- `model_outdir/downscaled_preds_metadata.json`: Metadata for predictions
-- `model_outdir/training_sites.csv`: Training site list per PFT and pool
+- `model_outdir/downscaled_preds.csv`: Per-site, per-ensemble predictions with columns:
+  - `site_id`, `scenario`, `pft`, `ensemble`, `c_density_Mg_ha`, `total_c_Mg`, `area_ha`, `county`, `model_output`
+- `model_outdir/downscaled_preds_metadata.json`: Metadata including scenarios list
+- `model_outdir/downscaled_deltas.csv`: Carbon change from simulation start to end per scenario
+- `model_outdir/training_sites.csv`: Training site list per scenario, PFT, and pool
 - `cache/models/*_models.rds`: Saved RF models per spec
 - `cache/training_data/*_training.csv`: Training covariate matrices per spec
-- `model_outdir/downscaled_deltas.csv`: Optional start→end deltas when available
 
 **Outputs from `041_aggregate_to_county.R`:**
 - `model_outdir/county_summaries.csv`: County statistics (means/SDs across ensembles for stocks and densities)

--- a/scripts/030_extract_sipnet_output.R
+++ b/scripts/030_extract_sipnet_output.R
@@ -91,7 +91,6 @@ if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
 } else {
     
     #----------NetCDF extraction-------------------------------
-    PEcAn.logger::logger.info("Phase 2 mode: Extracting from NetCDF files")
     
     # Read settings file and extract run information
     settings <- PEcAn.settings::read.settings(file.path(pecan_outdir, "pecan.CONFIGS.xml"))

--- a/scripts/030_extract_sipnet_output.R
+++ b/scripts/030_extract_sipnet_output.R
@@ -7,16 +7,13 @@
 # 2. A NetCDF file (time, site, ensemble, variable)
 # TODO: write out EML metadata in order to be fully EFI compliant
 
-
-## First, uncompress the model output
-# tar --use-compress-program="pigz -d" -xf ccmmf_phase_2a_DRAFT_output_20250516.tgz
-# tar --use-compress-program="pigz -d" -xf ccmmf_phase_2a_DRAFT_output_20250516.tgz --wildcards '*.nc'
-
-## Second, make sure ccmmf_dir and pecan_outdir are defined in the config file
 source("000-config.R")
 PEcAn.logger::logger.info("***Starting SIPNET output extraction***")
 
 #----------Management scenario extraction-------------------------------
+# phase 3 uses pre-extracted .Rdata files; phase 2 reads netcdf via PEcAn
+# TODO: once phase 3 reruns produce NetCDF output (with N2O/CH4), unify both
+# paths to use the netcdf extraction below
 # TODO: extend to support multi-PFT scenarios when woody crop management scenarios are added
 if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
     PEcAn.logger::logger.info("Loading pre-extracted scenario data")
@@ -80,12 +77,7 @@ if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
     ensemble_output_csv <- file.path(model_outdir, "ensemble_output.csv")
     readr::write_csv(ens_results, ensemble_output_csv)
     PEcAn.logger::logger.info(
-        "\nPhase 3 extraction complete.",
-        "\nScenarios: ", paste(unique(ens_results$scenario), collapse = ", "),
-        "\nSites: ", dplyr::n_distinct(ens_results$site_id),
-        "\nEnsembles: ", dplyr::n_distinct(ens_results$parameter),
-        "\nVariables: ", paste(unique(ens_results$variable), collapse = ", "),
-        "\nSaved to: ", ensemble_output_csv
+        "Phase 3 extraction complete. Saved to ", ensemble_output_csv
     )
     
 } else {
@@ -157,7 +149,7 @@ if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
     ens_ids <- 1:ensemble_size
     
     variables <- outputs_to_extract # TODO standardize this name; variables is ambiguous
-                                    # but is used by the PEcAn read.output function
+    # but is used by the PEcAn read.output function
     
     if (!PRODUCTION) {
         ## -----TESTING SUBSET----##
@@ -210,8 +202,8 @@ if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
         # .Bug report: https://github.com/r-quantities/units/issues/409
         # Fixed in units version >= 0.8.7
         .options = furrr::furrr_options(seed = TRUE)
-    ) 
-    
+    )
+
     ens_results <- ens_results_raw |>
         dplyr::group_by(parameter, base_site_id, pft, year) |>
         dplyr::ungroup() |>
@@ -235,7 +227,7 @@ if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
     
     pool_vars <- std_vars |>
         dplyr::filter(stringr::str_detect(tolower(Category), "pool")) |>
-        dplyr::pull(Variable.Name) 
+        dplyr::pull(Variable.Name)
     
     flux_vars <- std_vars |>
         dplyr::filter(stringr::str_detect(tolower(Category), "flux")) |>

--- a/scripts/030_extract_sipnet_output.R
+++ b/scripts/030_extract_sipnet_output.R
@@ -7,190 +7,276 @@
 # 2. A NetCDF file (time, site, ensemble, variable)
 # TODO: write out EML metadata in order to be fully EFI compliant
 
+
+## First, uncompress the model output
+# tar --use-compress-program="pigz -d" -xf ccmmf_phase_2a_DRAFT_output_20250516.tgz
+# tar --use-compress-program="pigz -d" -xf ccmmf_phase_2a_DRAFT_output_20250516.tgz --wildcards '*.nc'
+
 ## Second, make sure ccmmf_dir and pecan_outdir are defined in the config file
 source("000-config.R")
 PEcAn.logger::logger.info("***Starting SIPNET output extraction***")
-# Read settings file and extract run information
-settings <- PEcAn.settings::read.settings(file.path(pecan_outdir, "pecan.CONFIGS.xml"))
 
-ensemble_size <- settings$ensemble$size |>
-    as.numeric()
-start_date <- settings$run$settings.1$start.date
-start_year <- lubridate::year(start_date)
-end_date <- settings$run$settings.1$end.date
-end_year <- lubridate::year(end_date)
-
-
-design_points_csv <- "https://raw.githubusercontent.com/ccmmf/workflows/refs/tags/v0.2.0/data/design_points.csv"
-design_points <- readr::read_csv(design_points_csv)
-
-# Read the runs.txt file to get ensemble and site and directory information
-runs_file <- file.path(pecan_outdir, "run", "runs.txt")
-## Expected outputs based on runs.txt
-expected_ens_dirs <- tibble::tibble(
-    dir = readr::read_lines(runs_file)
-) |>
-    tidyr::separate(
-        col = "dir",
-        into = c("prefix", "ens", "site_id"),
-        sep = "-",
-        remove = FALSE
-    ) |>
-    dplyr::mutate(
-        # base ID has no suffix; used to match design_points
-        base_site_id = sub("_grass$", "", site_id),
-        # PFT determined by presence of the suffix in the actual site_id
-        pft = dplyr::if_else(
-            grepl("_grass$", site_id),
-            "annual crop",
-            "woody perennial crop"
-        )
-    ) |>
-    dplyr::select(-prefix)
-
-## Check that all expected are present
-actual_ens_dirs <- dir(model_outdir)
-dirs_present <- all(expected_ens_dirs$dir %in% actual_ens_dirs)
-if (!dirs_present) {
-    missing_dirs <- setdiff(expected_ens_dirs$dir, actual_ens_dirs)
-    PEcAn.logger::logger.severe(
-        "Not all expected ensemble directories are present in the model output directory.",
-        "Missing: ", paste(missing_dirs, collapse = ", ")
+#----------Management scenario extraction-------------------------------
+# TODO: extend to support multi-PFT scenarios when woody crop management scenarios are added
+if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
+    PEcAn.logger::logger.info("Loading pre-extracted scenario data")
+    
+    rdata_files <- list.files(
+        pecan_outdir,
+        pattern = "^results_monthly_.*\\.Rdata$",
+        full.names = TRUE
     )
-}
-ens_dirs <- expected_ens_dirs
-
-# Map each actual site_id (with/without suffix) to lat/lon via base_site_id
-site_meta <- ens_dirs |>
-    dplyr::distinct(site_id, base_site_id, pft) |>
-    dplyr::left_join(
-        design_points |> dplyr::select(site_id, lat, lon),
-        by = dplyr::join_by(base_site_id == site_id)
-    )
-
-site_ids <- site_meta |>
-    dplyr::pull(site_id) |>
-    unique()
-
-ens_ids <- 1:ensemble_size
-
-variables <- outputs_to_extract # TODO standardize this name; variables is ambiguous
-# but is used by the PEcAn read.output function
-
-if (!PRODUCTION) {
-    ## -----TESTING SUBSET----##
-    site_ids <- site_ids[1:10]
-    ens_ids <- ens_ids[1:10]
-    start_year <- end_year - 1
-}
-
-## Create dataframe of directories to process, filtered to include only
-##   existing directories (ens_dirs) that have site_ids and ensemble IDs
-ens_ids_str <- PEcAn.utils::left.pad.zeros(ens_ids)
-dirs_to_process <- ens_dirs |>
-    dplyr::filter(
-        site_id %in% site_ids,
-        ens %in% ens_ids_str
-    )
-
-ens_dirs_subset <- ens_dirs |>
-    dplyr::filter(
-        base_site_id %in% site_ids, # use base_site_id (site_id may include _grass)
-        as.numeric(ens) %in% ens_ids
-    ) |>
-    dplyr::mutate(dir = file.path(model_outdir, dir)) |>
-    dplyr::select(ens, site_id, dir, pft, base_site_id) # keep both ids
-
-# extract output via PEcAn.utils::read.output
-# temporarily suppress logging or else it will print a lot of file names
-logger_level <- PEcAn.logger::logger.setLevel("OFF")
-ens_results_raw <- furrr::future_pmap_dfr(
-    ens_dirs_subset,
-    function(ens, site_id, dir, pft, base_site_id) {
-        out_df <- PEcAn.utils::read.output(
-            runid = paste(ens, site_id, sep = "-"),
-            outdir = dir,
-            start.year = start_year,
-            end.year = end_year,
-            variables = variables,
-            dataframe = TRUE,
-            verbose = FALSE
-        ) |>
-            dplyr::mutate(
-                site_id = .env$site_id,
-                parameter = as.numeric(.env$ens),
-                pft = .env$pft,
-                base_site_id = .env$base_site_id
+    
+    if (length(rdata_files) == 0) {
+        PEcAn.logger::logger.severe("No pre-extracted .Rdata files found in ", pecan_outdir)
+    }
+    
+    # load site info for lat/lon
+    site_info <- readr::read_csv(file.path(pecan_outdir, "site_info.csv"))
+    
+    # process each variable file
+    all_results <- list()
+    for (rdata_file in rdata_files) {
+        var_name <- stringr::str_extract(basename(rdata_file), "(?<=results_monthly_)[^.]+")
+        
+        if (!var_name %in% outputs_to_extract) {
+            PEcAn.logger::logger.info("Skipping ", var_name, " (not in outputs_to_extract)")
+            next
+        }
+        
+        PEcAn.logger::logger.info("Loading ", var_name, " from ", basename(rdata_file))
+        load(rdata_file)  # loads 'results' dataframe
+        
+        # convert to EFI format
+        var_results <- results |>
+            dplyr::rename(
+                site_id = site,
+                parameter = ens_num,
+                datetime = posix
             ) |>
-            dplyr::rename(time = posix)
-    },
-    # Avoids warning "future unexpectedly generated random numbers",
-    # .Bug report: https://github.com/r-quantities/units/issues/409
-    # Fixed in units version >= 0.8.7
-    .options = furrr::furrr_options(seed = TRUE)
-)
-
-ens_results <- ens_results_raw |>
-    dplyr::group_by(parameter, base_site_id, pft, year) |>
-    dplyr::ungroup() |>
-    dplyr::arrange(parameter, base_site_id, pft, year) |>
-    tidyr::pivot_longer(
-        cols = tidyr::all_of(variables),
-        names_to = "variable",
-        values_to = "prediction"
+            dplyr::left_join(
+                site_info |> dplyr::select(id, lat, lon),
+                by = c("site_id" = "id")
+            ) |>
+            tidyr::pivot_longer(
+                cols = tidyr::all_of(var_name),
+                names_to = "variable",
+                values_to = "prediction"
+            ) |>
+            dplyr::mutate(
+                pft = "annual crop",
+                datetime = lubridate::floor_date(datetime, unit = "month"),
+                variable_type = "pool"
+            ) |>
+            dplyr::group_by(scenario, datetime, site_id, lat, lon, pft, parameter, variable, variable_type) |>
+            dplyr::summarise(prediction = mean(prediction, na.rm = TRUE), .groups = "drop")
+        
+        all_results[[var_name]] <- var_results
+    }
+    
+    ens_results <- dplyr::bind_rows(all_results)
+    
+    # write output
+    ensemble_output_csv <- file.path(model_outdir, "ensemble_output.csv")
+    readr::write_csv(ens_results, ensemble_output_csv)
+    PEcAn.logger::logger.info(
+        "\nPhase 3 extraction complete.",
+        "\nScenarios: ", paste(unique(ens_results$scenario), collapse = ", "),
+        "\nSites: ", dplyr::n_distinct(ens_results$site_id),
+        "\nEnsembles: ", dplyr::n_distinct(ens_results$parameter),
+        "\nVariables: ", paste(unique(ens_results$variable), collapse = ", "),
+        "\nSaved to: ", ensemble_output_csv
+    )
+    
+} else {
+    
+    #----------NetCDF extraction-------------------------------
+    PEcAn.logger::logger.info("Phase 2 mode: Extracting from NetCDF files")
+    
+    # Read settings file and extract run information
+    settings <- PEcAn.settings::read.settings(file.path(pecan_outdir, "pecan.CONFIGS.xml"))
+    
+    ensemble_size <- settings$ensemble$size |>
+        as.numeric()
+    start_date <- settings$run$settings.1$start.date
+    start_year <- lubridate::year(start_date)
+    end_date <- settings$run$settings.1$end.date
+    end_year <- lubridate::year(end_date)
+    
+    
+    design_points_csv <- "https://raw.githubusercontent.com/ccmmf/workflows/refs/tags/v0.2.0/data/design_points.csv"
+    design_points <- readr::read_csv(design_points_csv)
+    
+    # Read the runs.txt file to get ensemble and site and directory information
+    runs_file <- file.path(pecan_outdir, "run", "runs.txt")
+    ## Expected outputs based on runs.txt
+    expected_ens_dirs <- tibble::tibble(
+        dir = readr::read_lines(runs_file)
     ) |>
-    dplyr::rename(datetime = time) |>
-    dplyr::left_join(site_meta,
-        by = c("site_id", "base_site_id", "pft")
-    ) |>
-    dplyr::select(-site_id) |>
-    dplyr::rename(site_id = base_site_id) |>
-    dplyr::select(datetime, site_id, lat, lon, pft, parameter, variable, prediction)
-
-# Classify variables as 'pool' (state) vs 'flux' (rate) using PEcAn standard_vars.
-std_vars <- PEcAn.utils::standard_vars
-
-pool_vars <- std_vars |>
-    dplyr::filter(stringr::str_detect(tolower(Category), "pool")) |>
-    dplyr::pull(Variable.Name)
-
-flux_vars <- std_vars |>
-    dplyr::filter(stringr::str_detect(tolower(Category), "flux")) |>
-    dplyr::pull(Variable.Name)
-
-ens_results <- ens_results |>
-    dplyr::mutate(
-        datetime = lubridate::floor_date(datetime, unit = "month"),
-        variable_type = dplyr::case_when(
-            variable %in% pool_vars ~ "pool",
-            variable %in% flux_vars ~ "flux",
-            TRUE ~ "unknown"
+        tidyr::separate(
+            col = "dir",
+            into = c("prefix", "ens", "site_id"),
+            sep = "-",
+            remove = FALSE
+        ) |>
+        dplyr::mutate(
+            # base ID has no suffix; used to match design_points
+            base_site_id = sub("_grass$", "", site_id),
+            # PFT determined by presence of the suffix in the actual site_id
+            pft = dplyr::if_else(
+                grepl("_grass$", site_id),
+                "annual crop",
+                "woody perennial crop"
+            )
+        ) |>
+        dplyr::select(-prefix)
+    
+    ## Check that all expected are present
+    actual_ens_dirs <- dir(model_outdir)
+    dirs_present <- all(expected_ens_dirs$dir %in% actual_ens_dirs)
+    if (!dirs_present) {
+        missing_dirs <- setdiff(expected_ens_dirs$dir, actual_ens_dirs)
+        PEcAn.logger::logger.severe(
+            "Not all expected ensemble directories are present in the model output directory.",
+            "Missing: ", paste(missing_dirs, collapse = ", ")
         )
-    ) |>
-    dplyr::group_by(datetime, site_id, lat, lon, pft, parameter, variable, variable_type) |>
-    dplyr::summarise(
-        prediction = mean(prediction, na.rm = TRUE),
-        .groups = "drop"
+    }
+    ens_dirs <- expected_ens_dirs
+    
+    # Map each actual site_id (with/without suffix) to lat/lon via base_site_id
+    site_meta <- ens_dirs |>
+        dplyr::distinct(site_id, base_site_id, pft) |>
+        dplyr::left_join(
+            design_points |> dplyr::select(site_id, lat, lon),
+            by = dplyr::join_by(base_site_id == site_id)
+        )
+    
+    site_ids <- site_meta |>
+        dplyr::pull(site_id) |>
+        unique()
+    
+    ens_ids <- 1:ensemble_size
+    
+    variables <- outputs_to_extract # TODO standardize this name; variables is ambiguous
+                                    # but is used by the PEcAn read.output function
+    
+    if (!PRODUCTION) {
+        ## -----TESTING SUBSET----##
+        site_ids <- site_ids[1:10]
+        ens_ids <- ens_ids[1:10]
+        start_year <- end_year - 1
+    }
+    
+    ## Create dataframe of directories to process, filtered to include only
+    ##   existing directories (ens_dirs) that have site_ids and ensemble IDs
+    ens_ids_str <- PEcAn.utils::left.pad.zeros(ens_ids)
+    dirs_to_process <- ens_dirs |>
+        dplyr::filter(
+            site_id %in% site_ids,
+            ens %in% ens_ids_str
+        )
+    
+    ens_dirs_subset <- ens_dirs |>
+        dplyr::filter(
+            base_site_id %in% site_ids, # use base_site_id (site_id may include _grass)
+            as.numeric(ens) %in% ens_ids
+        ) |>
+        dplyr::mutate(dir = file.path(model_outdir, dir)) |>
+        dplyr::select(ens, site_id, dir, pft, base_site_id) # keep both ids
+    
+    # extract output via PEcAn.utils::read.output
+    # temporarily suppress logging or else it will print a lot of file names
+    logger_level <- PEcAn.logger::logger.setLevel("OFF")
+    ens_results_raw <- furrr::future_pmap_dfr(
+        ens_dirs_subset,
+        function(ens, site_id, dir, pft, base_site_id) {
+            out_df <- PEcAn.utils::read.output(
+                runid = paste(ens, site_id, sep = "-"),
+                outdir = dir,
+                start.year = start_year,
+                end.year = end_year,
+                variables = variables,
+                dataframe = TRUE,
+                verbose = FALSE
+            ) |>
+                dplyr::mutate(
+                    site_id = .env$site_id,
+                    parameter = as.numeric(.env$ens),
+                    pft = .env$pft,
+                    base_site_id = .env$base_site_id
+                ) |>
+                dplyr::rename(time = posix)
+        },
+        # Avoids warning "future unexpectedly generated random numbers",
+        # .Bug report: https://github.com/r-quantities/units/issues/409
+        # Fixed in units version >= 0.8.7
+        .options = furrr::furrr_options(seed = TRUE)
+    ) 
+    
+    ens_results <- ens_results_raw |>
+        dplyr::group_by(parameter, base_site_id, pft, year) |>
+        dplyr::ungroup() |>
+        dplyr::arrange(parameter, base_site_id, pft, year) |>
+        tidyr::pivot_longer(
+            cols = tidyr::all_of(variables),
+            names_to = "variable",
+            values_to = "prediction"
+        ) |>
+        dplyr::rename(datetime = time) |>
+        dplyr::left_join(site_meta,
+            by = c("site_id", "base_site_id", "pft")
+        ) |>
+        dplyr::select(-site_id) |>
+        dplyr::rename(site_id = base_site_id) |>
+        dplyr::mutate(scenario = "baseline") |>  # Add scenario column for consistency
+        dplyr::select(scenario, datetime, site_id, lat, lon, pft, parameter, variable, prediction)
+    
+    # Classify variables as 'pool' (state) vs 'flux' (rate) using PEcAn standard_vars.
+    std_vars <- PEcAn.utils::standard_vars
+    
+    pool_vars <- std_vars |>
+        dplyr::filter(stringr::str_detect(tolower(Category), "pool")) |>
+        dplyr::pull(Variable.Name) 
+    
+    flux_vars <- std_vars |>
+        dplyr::filter(stringr::str_detect(tolower(Category), "flux")) |>
+        dplyr::pull(Variable.Name)
+    
+    ens_results <- ens_results |>
+        dplyr::mutate(
+            datetime = lubridate::floor_date(datetime, unit = "month"),
+            variable_type = dplyr::case_when(
+                variable %in% pool_vars ~ "pool",
+                variable %in% flux_vars ~ "flux",
+                TRUE ~ "unknown"
+            )
+        ) |>
+        dplyr::group_by(scenario, datetime, site_id, lat, lon, pft, parameter, variable, variable_type) |>
+        dplyr::summarise(
+            prediction = mean(prediction, na.rm = TRUE),
+            .groups = "drop"
+        )
+    
+    # Warn if flux variables are present because users may need to treat them differently.
+    if (any(ens_results$variable_type == "flux")) {
+        PEcAn.logger::logger.severe(
+            "Flux variables detected in ensemble output. Note: averaging flux (rate) variables",
+            "across ensembles/sites or over time can be misleading. Consider computing cumulative",
+            "fluxes over simulation period",
+        )
+    }
+    
+    # After extraction, ens_results$prediction is in kg C m-2 for both AGB and TotSoilCarb
+    
+    # restore logging
+    logger_level <- PEcAn.logger::logger.setLevel(logger_level)
+    
+    ensemble_output_csv <- file.path(model_outdir, "ensemble_output.csv")
+    readr::write_csv(ens_results, ensemble_output_csv)
+    PEcAn.logger::logger.info(
+        "\nEnsemble output extraction complete.",
+        "\nResults saved to ", ensemble_output_csv
     )
-
-# Warn if flux variables are present because users may need to treat them differently.
-if (any(ens_results$variable_type == "flux")) {
-    PEcAn.logger::logger.severe(
-        "Flux variables detected in ensemble output. Note: averaging flux (rate) variables",
-        "across ensembles/sites or over time can be misleading. Consider computing cumulative",
-        "fluxes over simulation period",
-    )
+    PEcAn.logger::logger.setLevel(logger_level)
+    
 }
-
-# After extraction, ens_results$prediction is in kg C m-2 for both AGB and TotSoilCarb
-
-# restore logging
-logger_level <- PEcAn.logger::logger.setLevel(logger_level)
-
-ensemble_output_csv <- file.path(model_outdir, "ensemble_output.csv")
-readr::write_csv(ens_results, ensemble_output_csv)
-PEcAn.logger::logger.info(
-    "\nEnsemble output extraction complete.",
-    "\nResults saved to ", ensemble_output_csv
-)
-PEcAn.logger::logger.setLevel(logger_level)

--- a/scripts/031_aggregate_sipnet_output.R
+++ b/scripts/031_aggregate_sipnet_output.R
@@ -16,6 +16,16 @@
 
 source("000-config.R")
 
+# skip for single-PFT management scenarios (multi-PFT aggregation not applicable)
+# TODO: extend to support multi-PFT management scenarios when woody crop scenarios are added
+if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
+  PEcAn.logger::logger.info(
+    "Skipping multi-PFT aggregation (single PFT scenarios).",
+    "Proceeding directly to 040_downscale.R"
+  )
+  quit(save = "no", status = 0)
+}
+
 PEcAn.logger::logger.info("*** Starting multi-PFT aggregation ***")
 
 # ---- Load ensemble output ----------------------------------------------------

--- a/scripts/040_downscale.R
+++ b/scripts/040_downscale.R
@@ -22,11 +22,23 @@ ensemble_data <- readr::read_csv(ensemble_csv) |>
   dplyr::rename(
     ensemble = parameter # parameter is EFI std name for ensemble
   )
+
+# detect scenario mode (Phase 3 has scenario column, Phase 2 does not)
+has_scenarios <- "scenario" %in% names(ensemble_data)
+if (has_scenarios) {
+  scenarios <- unique(ensemble_data$scenario)
+  PEcAn.logger::logger.info("Scenario mode: ", paste(scenarios, collapse = ", "))
+} else {
+  scenarios <- "baseline"
+  ensemble_data <- ensemble_data |> dplyr::mutate(scenario = "baseline")
+}
+
 PEcAn.logger::logger.info(
   "Loaded ensemble data:", nrow(ensemble_data), "rows;",
   dplyr::n_distinct(ensemble_data$site_id), "unique site_ids;",
   dplyr::n_distinct(ensemble_data$ensemble), "ensembles;",
   dplyr::n_distinct(ensemble_data$pft), "PFTs;",
+  length(scenarios), "scenarios;",
   dplyr::n_distinct(ensemble_data$variable), "variables (carbon pools) in file; load_time_s=",
   round(step_elapsed(timer_read_ensemble), 2)
 )
@@ -190,35 +202,53 @@ extract_oob_r2 <- function(model, y_train = NULL) {
 #   ca_field_attributes
 # )
 
-# TODO: Need to put a canonical design_points CSV in repository
-### FOR NOW, just use hard coded design points
-design_points <- structure(list(site_id = c(
-  "3a84c0268e1655a3", "3a84c0268e1655a3",
-  "d523652b399a8f6e", "d523652b399a8f6e", "275102c035b15f5e", "275102c035b15f5e",
-  "26ff9e8246f7c8f4", "26ff9e8246f7c8f4", "47cd11223bb49112", "47cd11223bb49112",
-  "9a4c7e47fc0297bb", "9a4c7e47fc0297bb", "e5bb4dca46bd5041", "e5bb4dca46bd5041",
-  "abd5a71d492e92e1", "abd5a71d492e92e1", "7fe5bb855fb36cdb", "7fe5bb855fb36cdb",
-  "7bb77bae6ac3c147", "7bb77bae6ac3c147"
-), lat = c(
-  34.91295, 34.91295,
-  34.38596, 34.38596, 34.47244, 34.47244, 33.86884, 33.86884, 34.29708,
-  34.29708, 33.96727, 33.96727, 33.35306, 33.35306, 34.37258, 34.37258,
-  33.90119, 33.90119, 33.57847, 33.57847
-), lon = c(
-  -120.40345,
-  -120.40345, -118.81446, -118.81446, -119.22015, -119.22015, -117.40838,
-  -117.40838, -119.06014, -119.06014, -117.34049, -117.34049, -117.19182,
-  -117.19182, -119.03318, -119.03318, -117.40624, -117.40624, -116.03157,
-  -116.03157
-), pft = c(
-  "woody perennial crop", "annual crop", "woody perennial crop", "annual crop", "woody perennial crop",
-  "annual crop", "woody perennial crop", "annual crop", "woody perennial crop", "annual crop", "woody perennial crop", "annual crop",
-  "woody perennial crop", "annual crop", "woody perennial crop", "annual crop", "woody perennial crop", "annual crop", "woody perennial crop",
-  "annual crop"
-)), row.names = c(NA, -20L), class = c(
-  "tbl_df", "tbl",
-  "data.frame"
-))
+
+# TODO: unify design point loading across modes when multi-PFT scenarios are added
+if (exists("USE_PHASE_3_SCENARIOS") && USE_PHASE_3_SCENARIOS) {
+  site_info <- readr::read_csv(file.path(pecan_outdir, "site_info.csv"))
+  design_points <- site_info |>
+    dplyr::transmute(
+      site_id = id,
+      lat = lat,
+      lon = lon,
+      pft = dplyr::case_when(
+        site.pft == "annual_crop" ~ "annual crop",
+        TRUE ~ site.pft
+      )
+    )
+  PEcAn.logger::logger.info("phase 3: loaded ", nrow(design_points), " design points from site_info.csv")
+} else {
+  # Phase 2: hard-coded design points
+  # TODO: Need to put a canonical design_points CSV in repository
+  ### FOR NOW, just use hard coded design points
+  design_points <- structure(list(site_id = c(
+    "3a84c0268e1655a3", "3a84c0268e1655a3",
+    "d523652b399a8f6e", "d523652b399a8f6e", "275102c035b15f5e", "275102c035b15f5e",
+    "26ff9e8246f7c8f4", "26ff9e8246f7c8f4", "47cd11223bb49112", "47cd11223bb49112",
+    "9a4c7e47fc0297bb", "9a4c7e47fc0297bb", "e5bb4dca46bd5041", "e5bb4dca46bd5041",
+    "abd5a71d492e92e1", "abd5a71d492e92e1", "7fe5bb855fb36cdb", "7fe5bb855fb36cdb",
+    "7bb77bae6ac3c147", "7bb77bae6ac3c147"
+  ), lat = c(
+    34.91295, 34.91295,
+    34.38596, 34.38596, 34.47244, 34.47244, 33.86884, 33.86884, 34.29708,
+    34.29708, 33.96727, 33.96727, 33.35306, 33.35306, 34.37258, 34.37258,
+    33.90119, 33.90119, 33.57847, 33.57847
+  ), lon = c(
+    -120.40345,
+    -120.40345, -118.81446, -118.81446, -119.22015, -119.22015, -117.40838,
+    -117.40838, -119.06014, -119.06014, -117.34049, -117.34049, -117.19182,
+    -117.19182, -119.03318, -119.03318, -117.40624, -117.40624, -116.03157,
+    -116.03157
+  ), pft = c(
+    "woody perennial crop", "annual crop", "woody perennial crop", "annual crop", "woody perennial crop",
+    "annual crop", "woody perennial crop", "annual crop", "woody perennial crop", "annual crop", "woody perennial crop", "annual crop",
+    "woody perennial crop", "annual crop", "woody perennial crop", "annual crop", "woody perennial crop", "annual crop", "woody perennial crop",
+    "annual crop"
+  )), row.names = c(NA, -20L), class = c(
+    "tbl_df", "tbl",
+    "data.frame"
+  ))
+}
 
 stopifnot(all(design_points$site_id %in% covariates$site_id))
 
@@ -351,61 +381,61 @@ downscale_model_output <- function(date,
 }
 
 # not using furrr b/c it is used inside downscale
-# We downscale each carbon pool for both woody and annual PFTs,
+# we downscale each carbon pool for each scenario and PFT,
 # predicting to the same target set for that PFT
 downscale_output_list <- list()
 delta_output_records <- list()
 training_sites_records <- list()
-combo_total <- length(outputs_to_extract) * length(pfts)
+combo_total <- length(scenarios) * length(outputs_to_extract) * length(pfts)
 combo_index <- 0L
 loop_global_timer <- step_timer()
-for (pool in outputs_to_extract) {
-  for (pft_i in pfts) {
-    combo_index <- combo_index + 1L
-    iter_timer <- step_timer()
-    PEcAn.logger::logger.info(
-      sprintf(
-        "[Progress %d/%d] Starting downscaling for %s (%s) at %s",
-        combo_index, combo_total, pool, pft_i, ts_now()
-      )
-    )
 
-    # train_ens: ensemble data filtered by PFT
-    train_ens <- ensemble_data |>
-      dplyr::filter(pft == pft_i & variable == pool)
-
-    # Skip empty slices early
-    if (nrow(train_ens) == 0) {
-      PEcAn.logger::logger.warn("No ensemble rows for ", pft_i, "::", pool, " <U+2014> skipping")
-      next
-    }
-
-    # Determine per-slice end date and warn if ensembles disagree
-    slice_end_date <- as.Date(max(train_ens$datetime))
-    end_by_ens <- train_ens |>
-      dplyr::group_by(ensemble) |>
-      dplyr::summarise(last_date = max(lubridate::as_date(datetime)), .groups = "drop")
-    if (dplyr::n_distinct(end_by_ens$last_date) > 1) {
-      PEcAn.logger::logger.warn(
-        "End dates vary across ensembles for ", pft_i, "::", pool,
-        "; using slice_end_date=", as.character(slice_end_date)
-      )
-    } else {
+for (scenario_i in scenarios) {
+  PEcAn.logger::logger.info("=== Processing scenario: ", scenario_i, " ===")
+  
+  for (pool in outputs_to_extract) {
+    for (pft_i in pfts) {
+      combo_index <- combo_index + 1L
+      iter_timer <- step_timer()
       PEcAn.logger::logger.info(
-        "Using slice_end_date=", as.character(slice_end_date), " for ", pft_i, "::", pool
+        sprintf(
+          "[Progress %d/%d] %s / %s / %s at %s",
+          combo_index, combo_total, scenario_i, pool, pft_i, ts_now()
+        )
       )
-    }
-    # train_pts: design points filtered by PFT
-    train_pts <- train_ens |>
-      dplyr::select(site_id, lat, lon, pft) |>
-      dplyr::distinct()
 
-    # Diagnostic: overlapping site counts
-    n_train_ens_sites <- length(unique(train_ens$site_id))
-    n_train_pts <- nrow(train_pts)
-    PEcAn.logger::logger.info("Training sites: ensemble has", n_train_ens_sites, "site_ids; using", n_train_pts, "coords")
-    training_sites_records[[paste0(pft_i, "::", pool)]] <-
-      tibble::tibble(site_id = unique(train_pts$site_id), pft = pft_i, model_output = pool)
+      # train_ens: ensemble data filtered by scenario, PFT, and pool
+      train_ens <- ensemble_data |>
+        dplyr::filter(scenario == scenario_i, pft == pft_i, variable == pool)
+
+      # Skip empty slices early
+      if (nrow(train_ens) == 0) {
+        PEcAn.logger::logger.warn("No data for ", scenario_i, "::", pft_i, "::", pool, " - skipping")
+        next
+      }
+
+      # Determine per-slice end date and warn if ensembles disagree
+      slice_end_date <- as.Date(max(train_ens$datetime))
+      end_by_ens <- train_ens |>
+        dplyr::group_by(ensemble) |>
+        dplyr::summarise(last_date = max(lubridate::as_date(datetime)), .groups = "drop")
+      if (dplyr::n_distinct(end_by_ens$last_date) > 1) {
+        PEcAn.logger::logger.warn(
+          "End dates vary across ensembles for ", scenario_i, "::", pft_i, "::", pool
+        )
+      }
+
+      # train_pts: design points filtered by PFT
+      train_pts <- train_ens |>
+        dplyr::select(site_id, lat, lon, pft) |>
+        dplyr::distinct()
+
+      # Diagnostic: overlapping site counts
+      n_train_ens_sites <- length(unique(train_ens$site_id))
+      n_train_pts <- nrow(train_pts)
+      PEcAn.logger::logger.info("Training sites: ", n_train_ens_sites, "; coords: ", n_train_pts)
+      training_sites_records[[paste0(scenario_i, "::", pft_i, "::", pool)]] <-
+        tibble::tibble(site_id = unique(train_pts$site_id), scenario = scenario_i, pft = pft_i, model_output = pool)
 
     # Ensure design point covariates are included for training join
     dp_pft <- design_covariates_unscaled |>
@@ -527,8 +557,8 @@ for (pool in outputs_to_extract) {
       }
     }
 
-    # store using pft::pool names (e.g. "woody::AGB").
-    downscale_output_list[[paste0(pft_i, "::", pool)]] <- result
+    # store using scenario::pft::pool names
+    downscale_output_list[[paste0(scenario_i, "::", pft_i, "::", pool)]] <- result
     if (!is.null(result) && !is.null(start_obj)) {
       end_df <- purrr::map(
         result$predictions,
@@ -553,7 +583,7 @@ for (pool in outputs_to_extract) {
           delta_total_c_Mg = delta_c_density_Mg_ha * area_ha
         ) |>
         dplyr::select(site_id, pft, ensemble, delta_c_density_Mg_ha, delta_total_c_Mg, area_ha, county, model_output)
-      delta_output_records[[paste0(pft_i, "::", pool)]] <- delta_df
+      delta_output_records[[paste0(scenario_i, "::", pft_i, "::", pool)]] <- delta_df
     }
 
     # Incremental checkpoint (so production runs can be resumed)
@@ -574,8 +604,9 @@ for (pool in outputs_to_extract) {
         step_elapsed(iter_timer), step_elapsed(loop_global_timer)
       )
     )
-  }
-}
+    } # end pft_i loop
+  } # end pool loop
+} # end scenario_i loop
 
 if (length(downscale_output_list) == 0) {
   PEcAn.logger::logger.severe("No downscale outputs produced")
@@ -634,12 +665,12 @@ get_downscale_preds <- function(downscale_obj) {
     dplyr::left_join(ca_fields, by = "site_id")
 }
 
-# Assemble predictions; carry PFT label by parsing element name: "{pft}::{pool}"
+# Assemble predictions; carry scenario/PFT label by parsing element name: "{scenario}::{pft}::{pool}"
 downscale_preds <- purrr::map(downscale_output_list, get_downscale_preds) |>
   dplyr::bind_rows(.id = "spec") |>
   tidyr::separate(
     col = "spec",
-    into = c("pft", "model_output"),
+    into = c("scenario", "pft", "model_output"),
     sep = "::",
     remove = TRUE
   ) |>
@@ -647,11 +678,11 @@ downscale_preds <- purrr::map(downscale_output_list, get_downscale_preds) |>
   dplyr::mutate(c_density_Mg_ha = PEcAn.utils::ud_convert(prediction, "kg/m2", "Mg/ha")) |>
   # Calculate total Mg per field: c_density_Mg_ha * area_ha
   dplyr::mutate(total_c_Mg = c_density_Mg_ha * area_ha) |>
-  dplyr::select(site_id, pft, ensemble, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output, -prediction)
+  dplyr::select(site_id, scenario, pft, ensemble, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output, -prediction)
 
 dp <- downscale_preds |>
   dplyr::select(
-    site_id, pft, ensemble,
+    site_id, scenario, pft, ensemble,
     c_density_Mg_ha, total_c_Mg,
     area_ha, county, model_output
   )
@@ -666,186 +697,204 @@ dp <- downscale_preds |>
 woody_label <- pfts[grepl("woody", pfts, ignore.case = TRUE)]
 annual_label <- pfts[grepl("annual", pfts, ignore.case = TRUE)]
 
-if (is.na(woody_label) | is.na(annual_label)) {
+if (length(woody_label) == 0 || length(annual_label) == 0) {
   PEcAn.logger::logger.warn("Cannot build mixed scenario: missing woody or annual PFT")
 } else {
   PEcAn.logger::logger.info(
     "Building mixed scenario 'woody + annual' using overlap (incremental) with 50% annual cover"
   )
-}
-
-# Helper to tidy a downscale object to site_id/ensemble/prediction (kg/m2)
-tidy_downscale <- function(ds) {
-  purrr::map(
-    ds$predictions,
-    ~ tibble::tibble(site_id = ds$site_ids, prediction = .x)
-  ) |>
-    dplyr::bind_rows(.id = "ensemble")
-}
-
-# Determine target woody sites that exist in current dp
-target_woody_sites <- dp |>
-  dplyr::filter(pft == woody_label) |>
-  dplyr::distinct(site_id) |>
-  dplyr::pull(site_id)
-
-# If no woody sites present, skip
-if (length(target_woody_sites) == 0) {
-  PEcAn.logger::logger.warn("No woody sites found in downscaled predictions; skipping mixed scenario")
-} else {
-  # Build covariates for predicting annual onto woody sites, ensuring
-  # design-point covariates for the annual PFT are available for training join
-  dp_annual <- design_covariates_unscaled |>
-    dplyr::filter(site_id %in% (design_points |>
-      dplyr::filter(pft == annual_label) |>
-      dplyr::pull(site_id)))
-
-  pred_cov_mixed <- covariates_full |>
-    dplyr::filter(site_id %in% target_woody_sites) |>
-    dplyr::bind_rows(dp_annual) |>
-    dplyr::distinct(site_id, .keep_all = TRUE)
-
-  mixed_records <- list()
-
-  for (pool in outputs_to_extract) {
-    # Training data for annual
-    train_ens_annual <- ensemble_data |>
-      dplyr::filter(pft == annual_label & variable == pool)
-
-    if (nrow(train_ens_annual) == 0) {
-      PEcAn.logger::logger.warn("No annual ensemble data for pool ", pool, "; skipping mixed for this pool")
-      next
-    }
-
-    train_pts_annual <- train_ens_annual |>
-      dplyr::select(site_id, lat, lon, pft) |>
-      dplyr::distinct()
-
-    # Annual predictions at start and end dates on woody sites
-    annual_start_obj <- downscale_model_output(
-      date = start_date,
-      model_output = pool,
-      train_ensemble_data = train_ens_annual,
-      train_site_coords = train_pts_annual,
-      pred_covariates = pred_cov_mixed
-    )
-    annual_end_obj <- downscale_model_output(
-      date = end_date,
-      model_output = pool,
-      train_ensemble_data = train_ens_annual,
-      train_site_coords = train_pts_annual,
-      pred_covariates = pred_cov_mixed
-    )
-
-    # Get woody predictions at end date from existing results
-    woody_key <- paste0(woody_label, "::", pool)
-    woody_obj <- downscale_output_list[[woody_key]]
-
-    if (is.null(annual_start_obj) || is.null(annual_end_obj) || is.null(woody_obj)) {
-      PEcAn.logger::logger.warn("Missing components for mixed scenario in pool ", pool, "; skipping")
-      next
-    }
-
-    woody_df <- tidy_downscale(woody_obj) |>
-      dplyr::filter(site_id %in% target_woody_sites) |>
-      dplyr::rename(woody_pred = prediction)
-
-    ann_start_df <- tidy_downscale(annual_start_obj) |>
-      dplyr::filter(site_id %in% target_woody_sites) |>
-      dplyr::rename(annual_start = prediction)
-
-    ann_end_df <- tidy_downscale(annual_end_obj) |>
-      dplyr::filter(site_id %in% target_woody_sites) |>
-      dplyr::rename(annual_end = prediction)
-
-    # Join by site_id and ensemble to align predictions (include annual_start for SOC)
-    mix_df <- woody_df |>
-      dplyr::inner_join(ann_end_df,  by = c("site_id", "ensemble")) |>
-      dplyr::inner_join(ann_start_df, by = c("site_id", "ensemble"))
-
-    if (nrow(mix_df) == 0) {
-      PEcAn.logger::logger.warn("No overlapping site/ensemble rows for mixed scenario in pool ", pool)
-      next
-    }
-
-    f_annual <- 0.5 # TODO: will come from monitoring / scenario data later
-    mix_df <- mix_df |>
-      dplyr::mutate(
-        mixed_pred = combine_mixed_crops(
-          woody_value = .data$woody_pred,
-          annual_value = .data$annual_end,
-          annual_init = if (pool == "AGB") 0 else .data$annual_start,
-          annual_cover = f_annual,
-          woody_cover = 1.0,
-          method = "incremental"
-        )
-      ) |>
-      # add area/county for totals
-      dplyr::left_join(ca_fields, by = "site_id") |>
-      dplyr::mutate(
-        pft = "woody + annual",
-        model_output = pool,
-        c_density_Mg_ha = PEcAn.utils::ud_convert(mixed_pred, "kg/m2", "Mg/ha"),
-        total_c_Mg = c_density_Mg_ha * area_ha
-      ) |>
-      dplyr::select(site_id, pft, ensemble, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
-
-    mixed_records[[pool]] <- mix_df
-
-    # Also save per-site treatment scenarios on woody fields for comparisons
-    woody_scn <- woody_df |>
-      dplyr::left_join(ca_fields, by = "site_id") |>
-      dplyr::mutate(
-        pft = pft_i,
-        model_output = pool,
-        scenario = "woody_100",
-        c_density_Mg_ha = PEcAn.utils::ud_convert(woody_pred, "kg/m2", "Mg/ha"),
-        total_c_Mg = c_density_Mg_ha * area_ha
-      ) |>
-      dplyr::select(site_id, pft, ensemble, scenario, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
-
-    annual_scn <- ann_end_df |>
-      dplyr::left_join(ca_fields, by = "site_id") |>
-      dplyr::mutate(
-        pft = pft_i,
-        model_output = pool,
-        scenario = "annual_100",
-        c_density_Mg_ha = PEcAn.utils::ud_convert(annual_end, "kg/m2", "Mg/ha"),
-        total_c_Mg = c_density_Mg_ha * area_ha
-      ) |>
-      dplyr::select(site_id, pft, ensemble, scenario, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
-
-    mixed_scn <- mix_df |>
-      dplyr::mutate(scenario = "woody_50_annual_50") |>
-      dplyr::select(site_id, pft, ensemble, scenario, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
-
-    # accumulate
-    if (!exists("treatment_records", inherits = FALSE)) treatment_records <- list()
-    treatment_records[[length(treatment_records) + 1L]] <- dplyr::bind_rows(woody_scn, annual_scn, mixed_scn)
+  
+  # Helper to tidy a downscale object to site_id/ensemble/prediction (kg/m2)
+  tidy_downscale <- function(ds) {
+    purrr::map(
+      ds$predictions,
+      ~ tibble::tibble(site_id = ds$site_ids, prediction = .x)
+    ) |>
+      dplyr::bind_rows(.id = "ensemble")
   }
-
-  # Append mixed records if any
-  if (length(mixed_records) > 0) {
-    mixed_df_all <- dplyr::bind_rows(mixed_records, .id = "pool") |>
-      dplyr::select(-pool)
-    dp <- dplyr::bind_rows(dp, mixed_df_all)
+  
+  # Determine target woody sites that exist in current dp
+  target_woody_sites <- dp |>
+    dplyr::filter(pft == woody_label) |>
+    dplyr::distinct(site_id) |>
+    dplyr::pull(site_id)
+  
+  # If no woody sites present, skip
+  if (length(target_woody_sites) == 0) {
+    PEcAn.logger::logger.warn("No woody sites found in downscaled predictions; skipping mixed scenario")
+  } else {
+    # Build covariates for predicting annual onto woody sites, ensuring
+    # design-point covariates for the annual PFT are available for training join
+    dp_annual <- design_covariates_unscaled |>
+      dplyr::filter(site_id %in% (design_points |>
+                                    dplyr::filter(pft == annual_label) |>
+                                    dplyr::pull(site_id)))
+    
+    pred_cov_mixed <- covariates_full |>
+      dplyr::filter(site_id %in% target_woody_sites) |>
+      dplyr::bind_rows(dp_annual) |>
+      dplyr::distinct(site_id, .keep_all = TRUE)
+    
+    mixed_records <- list()
+    
+    for (pool in outputs_to_extract) {
+      # Training data for annual
+      train_ens_annual <- ensemble_data |>
+        dplyr::filter(pft == annual_label & variable == pool)
+      
+      if (nrow(train_ens_annual) == 0) {
+        PEcAn.logger::logger.warn("No annual ensemble data for pool ", pool, "; skipping mixed for this pool")
+        next
+      }
+      
+      train_pts_annual <- train_ens_annual |>
+        dplyr::select(site_id, lat, lon, pft) |>
+        dplyr::distinct()
+      
+      # Annual predictions at start and end dates on woody sites
+      annual_start_obj <- downscale_model_output(
+        date = start_date,
+        model_output = pool,
+        train_ensemble_data = train_ens_annual,
+        train_site_coords = train_pts_annual,
+        pred_covariates = pred_cov_mixed
+      )
+      annual_end_obj <- downscale_model_output(
+        date = end_date,
+        model_output = pool,
+        train_ensemble_data = train_ens_annual,
+        train_site_coords = train_pts_annual,
+        pred_covariates = pred_cov_mixed
+      )
+      
+      # Get woody predictions at end date from existing results
+      woody_key <- paste0(woody_label, "::", pool)
+      woody_obj <- downscale_output_list[[woody_key]]
+      
+      if (is.null(annual_start_obj) || is.null(annual_end_obj) || is.null(woody_obj)) {
+        PEcAn.logger::logger.warn("Missing components for mixed scenario in pool ", pool, "; skipping")
+        next
+      }
+      
+      woody_df <- tidy_downscale(woody_obj) |>
+        dplyr::filter(site_id %in% target_woody_sites) |>
+        dplyr::rename(woody_pred = prediction)
+      
+      ann_start_df <- tidy_downscale(annual_start_obj) |>
+        dplyr::filter(site_id %in% target_woody_sites) |>
+        dplyr::rename(annual_start = prediction)
+      
+      ann_end_df <- tidy_downscale(annual_end_obj) |>
+        dplyr::filter(site_id %in% target_woody_sites) |>
+        dplyr::rename(annual_end = prediction)
+      
+      # Join by site_id and ensemble to align predictions (include annual_start for SOC)
+      mix_df <- woody_df |>
+        dplyr::inner_join(ann_end_df,  by = c("site_id", "ensemble")) |>
+        dplyr::inner_join(ann_start_df, by = c("site_id", "ensemble"))
+      
+      if (nrow(mix_df) == 0) {
+        PEcAn.logger::logger.warn("No overlapping site/ensemble rows for mixed scenario in pool ", pool)
+        next
+      }
+      
+      f_annual <- 0.5 # TODO: will come from monitoring / scenario data later
+      mix_df <- mix_df |>
+        dplyr::mutate(
+          mixed_pred = combine_mixed_crops(
+            woody_value = .data$woody_pred,
+            annual_value = .data$annual_end,
+            annual_init = if (pool == "AGB") 0 else .data$annual_start,
+            annual_cover = f_annual,
+            woody_cover = 1.0,
+            method = "incremental"
+          )
+        ) |>
+        # add area/county for totals
+        dplyr::left_join(ca_fields, by = "site_id") |>
+        dplyr::mutate(
+          pft = "woody + annual",
+          model_output = pool,
+          c_density_Mg_ha = PEcAn.utils::ud_convert(mixed_pred, "kg/m2", "Mg/ha"),
+          total_c_Mg = c_density_Mg_ha * area_ha
+        ) |>
+        dplyr::select(site_id, pft, ensemble, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
+      
+      mixed_records[[pool]] <- mix_df
+      
+      # Also save per-site treatment scenarios on woody fields for comparisons
+      woody_scn <- woody_df |>
+        dplyr::left_join(ca_fields, by = "site_id") |>
+        dplyr::mutate(
+          pft = pft_i,
+          model_output = pool,
+          scenario = "woody_100",
+          c_density_Mg_ha = PEcAn.utils::ud_convert(woody_pred, "kg/m2", "Mg/ha"),
+          total_c_Mg = c_density_Mg_ha * area_ha
+        ) |>
+        dplyr::select(site_id, pft, ensemble, scenario, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
+      
+      annual_scn <- ann_end_df |>
+        dplyr::left_join(ca_fields, by = "site_id") |>
+        dplyr::mutate(
+          pft = pft_i,
+          model_output = pool,
+          scenario = "annual_100",
+          c_density_Mg_ha = PEcAn.utils::ud_convert(annual_end, "kg/m2", "Mg/ha"),
+          total_c_Mg = c_density_Mg_ha * area_ha
+        ) |>
+        dplyr::select(site_id, pft, ensemble, scenario, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
+      
+      mixed_scn <- mix_df |>
+        dplyr::mutate(scenario = "woody_50_annual_50") |>
+        dplyr::select(site_id, pft, ensemble, scenario, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
+      
+      # accumulate
+      if (!exists("treatment_records", inherits = FALSE)) treatment_records <- list()
+      treatment_records[[length(treatment_records) + 1L]] <- dplyr::bind_rows(woody_scn, annual_scn, mixed_scn)
+    }
+    
+    # Append mixed records if any
+    if (length(mixed_records) > 0) {
+      mixed_df_all <- dplyr::bind_rows(mixed_records, .id = "pool") |>
+        dplyr::select(-pool)
+      dp <- dplyr::bind_rows(dp, mixed_df_all)
+    }
   }
 }
 
 
 ## Write out downscaled predictions
 
-readr::write_csv(
-  dp, # downscale predictions with mixed scenario appended (if available)
-  file.path(model_outdir, "downscaled_preds.csv")
+# Helper function to write CSV and optionally parquet
+write_output <- function(data, path_base, description = "data") {
+  csv_path <- paste0(path_base, ".csv")
+  readr::write_csv(data, csv_path)
+  PEcAn.logger::logger.info(description, " written to ", csv_path)
+  
+  # write parquet for large files (>100k rows) when arrow is available
+  if (nrow(data) > 100000 && requireNamespace("arrow", quietly = TRUE)) {
+    parquet_path <- paste0(path_base, ".parquet")
+    arrow::write_parquet(data, parquet_path)
+    PEcAn.logger::logger.info(description, " (parquet) written to ", parquet_path)
+  }
+}
+
+write_output(
+  dp,
+  file.path(model_outdir, "downscaled_preds"),
+  "Downscaled predictions"
 )
 
-# Write training site IDs used for each spec (pft x pool)
+# Training sites
 if (length(training_sites_records) > 0) {
   train_sites_df <- dplyr::bind_rows(training_sites_records) |>
     dplyr::distinct()
-  readr::write_csv(train_sites_df, file.path(model_outdir, "training_sites.csv"))
-  PEcAn.logger::logger.info("Training site list written to", file.path(model_outdir, "training_sites.csv"))
+  write_output(
+    train_sites_df,
+    file.path(model_outdir, "training_sites"),
+    "Training site list"
+  )
 }
 metadata <- list(
   title = "Downscaled SIPNET Outputs",
@@ -853,13 +902,15 @@ metadata <- list(
   created = Sys.time(),
   ensembles = sort(unique(as.integer(ensemble_ids))),
   pfts = pfts,
+  scenarios = scenarios,
   outputs_to_extract = outputs_to_extract,
   start_date = as.character(start_date),
   end_date = as.character(end_date),
-  mixed_cover_fraction = 0.5,
+  mixed_cover_fraction = if (length(scenarios) == 1) 0.5 else NA,
   columns = list(
     site_id = "Unique identifier for each field from LandIQ",
     pft = "Plant functional type",
+    scenario = "Management scenario (baseline, compost, etc.)",
     ensemble = "Ensemble member identifier",
     c_density_Mg_ha = "Predicted carbon density (Mg/ha)",
     total_c_Mg = "Predicted total carbon (Mg) per field",
@@ -875,22 +926,27 @@ metadata |>
     pretty = TRUE, auto_unbox = TRUE
   )
 
+# Delta predictions
 if (length(delta_output_records) > 0) {
   delta_dp <- dplyr::bind_rows(delta_output_records, .id = "spec") |>
-    tidyr::separate(col = "spec", into = c("pft", "model_output"), sep = "::", remove = TRUE)
-  readr::write_csv(delta_dp, file.path(model_outdir, "downscaled_deltas.csv"))
-  PEcAn.logger::logger.info("Delta predictions written to", file.path(model_outdir, "downscaled_deltas.csv"))
+    tidyr::separate(col = "spec", into = c("scenario", "pft", "model_output"), sep = "::", remove = TRUE)
+  write_output(
+    delta_dp,
+    file.path(model_outdir, "downscaled_deltas"),
+    "Delta predictions"
+  )
 }
 
-# Write treatment comparisons for woody sites if available
+# Treatment comparisons
 if (exists("treatment_records") && length(treatment_records) > 0) {
   treatments_df <- dplyr::bind_rows(treatment_records)
-  out_treat <- file.path(model_outdir, "treatments_woody_sites.csv")
-  readr::write_csv(treatments_df, out_treat)
-  PEcAn.logger::logger.info("Treatment scenarios written to", out_treat)
+  write_output(
+    treatments_df,
+    file.path(model_outdir, "treatments_woody_sites"),
+    "Treatment scenarios"
+  )
 }
 
-PEcAn.logger::logger.info("Downscaled predictions written to", file.path(model_outdir, "downscaled_preds.csv"))
 PEcAn.logger::logger.info(
   "Total script elapsed time (s):",
   round(step_elapsed(overall_timer), 2)


### PR DESCRIPTION
### Summary

Adds support for downscaling multiple management scenarios to field-level carbon estimates. The workflow now processes six agricultural practice scenarios (baseline, compost, reduced_till, zero_till, reduced_irrig_drip, stacked) and generates per-field predictions for annual croplands.

### Motivation

Closes [#167](https://github.com/ccmmf/organization/issues/167)

Comparing carbon outcomes across management practices requires field-scale predictions for each scenario. This enables to evaluate the relative impact of interventions such as compost application, tillage reduction, and drip irrigation on soil organic carbon and aboveground biomass.

### Notes

- Backward compatible: existing multi-PFT workflows (Phase 2) continue to work when `USE_PHASE_3_SCENARIOS = FALSE`