### PR TITLE
Aggregate downscaled scenario outputs to county and state level

### DIFF
--- a/000-config.R
+++ b/000-config.R
@@ -72,6 +72,11 @@ raw_data_dir <- file.path(ccmmf_dir, "data_raw")
 cache_dir <- file.path(ccmmf_dir, "cache")
 model_outdir <- file.path(pecan_outdir, "out")
 
+# Phase 3 cache lives alongside Phase 3 model output
+if (USE_PHASE_3_SCENARIOS) {
+  cache_dir <- file.path(phase_3_outdir, "cache")
+}
+
 # Misc
 set.seed(42)
 ca_albers_crs <- "EPSG:3310"

--- a/R/ggsave_optimized.R
+++ b/R/ggsave_optimized.R
@@ -82,7 +82,7 @@ ggsave_optimized <- function(
       if (isTRUE(png_quantize)) {
         img <- magick::image_read(filename)
         img <- magick::image_quantize(img, max = png_max)
-        magick::image_write(img, path = filename, format = "png", compression_level = 9)
+        magick::image_write(img, path = filename, format = "png")
       }
     }
     return(invisible(filename))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,15 +22,25 @@ sections to include in release notes:
 - Early exit in `031_aggregate_sipnet_output.R` for single-PFT runs
 - Parquet output for large files (>100k rows) via `write_output()` helper
 
+- County and state level aggregation with management scenario support
+  - `county_aggregated_preds.csv` replaces `county_summaries.csv`
+  - `county_aggregated_deltas.csv` for delta aggregation by scenario
+  - `state_summaries.csv` for California state-level totals
+  - `aggregation_metadata.json` with column descriptions
+- Field-level density maps replacing county density choropleth maps (per CARB request)
+- Backward compatibility for multi-PFT workflows without scenario column
+
 ### Fixed
 
 - Empty vector handling in mixed-scenario logic (`040_downscale.R`)
 
 ### Changed
 
+- County-level plots now include scenario in filenames (`043_county_level_plots.R`)
+
 ### Removed
 
-
+- County-level density choropleth maps (per CARB request; replaced with field-level point maps)
 
 ## 0.2.0-2a
 

--- a/docs/workflow_documentation.md
+++ b/docs/workflow_documentation.md
@@ -310,16 +310,21 @@ Builds Random Forest models to predict carbon pools for all fields; aggregates t
 - `cache/training_data/*_training.csv`: Training covariate matrices per spec
 
 **Outputs from `041_aggregate_to_county.R`:**
-- `model_outdir/county_summaries.csv`: County statistics (means/SDs across ensembles for stocks and densities)
+- `model_outdir/county_aggregated_preds.csv`: County statistics per scenario with columns:
+  - `scenario`, `model_output`, `pft`, `county`, `n`, `mean_total_c_Tg`, `sd_total_c_Tg`, `mean_c_density_Mg_ha`, `sd_c_density_Mg_ha`, `mean_total_ha`, `sd_total_ha`
+- `model_outdir/county_aggregated_deltas.csv`: County-level carbon change per scenario
+- `model_outdir/state_summaries.csv`: State-level totals per scenario
+- `model_outdir/aggregation_metadata.json`: Metadata for aggregated outputs
 
 **Outputs from `042_downscale_analysis.R` (saved in `figures/`):**
 - `<pft>_<pool>_importance_partial_plots.png`: Variable importance with partial plots for top predictors
 - `<pft>_<pool>_ALE_predictor<i>.svg` and `<pft>_<pool>_ICE_predictor<i>.svg`: ALE and ICE plots
 
 **Outputs from `043_county_level_plots.R` (saved in `figures/`):**
-- `county_<pft>_<pool>_carbon_stock.webp` and `county_<pft>_<pool>_carbon_density.webp`: County-level maps
-- `county_diff_woody_plus_annual_minus_woody_<pool>_carbon_{density,stock}.webp`: Scenario difference maps
-- `county_delta_<pft>_<pool>_carbon_{density,stock}.webp`: Start→end delta maps when available
+- `county_<scenario>_<pft>_<pool>_carbon_stock.webp`: County-level stock maps per scenario
+- `field_<scenario>_<pft>_<pool>_carbon_density.webp`: Field-level density point maps per scenario
+- `county_diff_woody_plus_annual_minus_woody_<pool>_carbon_stock.webp`: Difference maps (mixed - woody) - stock only
+- `county_delta_<scenario>_<pft>_<pool>_carbon_stock.webp`: Start→end delta stock maps when available
 
 ## Running on BU Cluster
 

--- a/docs/workflow_documentation.md
+++ b/docs/workflow_documentation.md
@@ -324,7 +324,7 @@ Builds Random Forest models to predict carbon pools for all fields; aggregates t
 - `county_<scenario>_<pft>_<pool>_carbon_stock.webp`: County-level stock maps per scenario
 - `field_<scenario>_<pft>_<pool>_carbon_density.webp`: Field-level density point maps per scenario
 - `county_diff_woody_plus_annual_minus_woody_<pool>_carbon_stock.webp`: Difference maps (mixed - woody) - stock only
-- `county_delta_<scenario>_<pft>_<pool>_carbon_stock.webp`: Start→end delta stock maps when available
+- `county_delta_<scenario>_<pft>_<pool>_carbon_stock.webp`: Start-to-end delta stock maps when available
 
 ## Running on BU Cluster
 

--- a/scripts/041_aggregate_to_county.R
+++ b/scripts/041_aggregate_to_county.R
@@ -1,19 +1,36 @@
-#### ---- Aggregate to County Level ---- ####
+#### ---- Aggregate to County and State Level ---- ####
 # Inputs: downscaling outputs saved by 040_downscale.R
-# Outputs: county_summaries.csv
+# Outputs:
+#   - county_aggregated_preds.csv: County-level summaries by scenario
+#   - county_aggregated_deltas.csv: County-level delta summaries by scenario
+#   - state_summaries.csv: State-level totals by scenario
+#   - aggregation_metadata.json: Metadata for aggregated outputs
 
-
-PEcAn.logger::logger.info("***Starting Aggregation to County Level***")
-
-
+PEcAn.logger::logger.info("***Starting Aggregation to County and State Level***")
 
 # Load configuration and paths
 source("000-config.R")
 
+# ---- Helper function for writing outputs ----
+write_output <- function(data, path_base, description = "data") {
+  csv_path <- paste0(path_base, ".csv")
+  readr::write_csv(data, csv_path)
+  PEcAn.logger::logger.info(description, " written to ", csv_path)
+  
+  # write parquet for large files (>100k rows) when arrow is available
+  if (nrow(data) > 100000 && requireNamespace("arrow", quietly = TRUE)) {
+    parquet_path <- paste0(path_base, ".parquet")
+    arrow::write_parquet(data, parquet_path)
+    PEcAn.logger::logger.info(description, " (parquet) written to ", parquet_path)
+  }
+}
+
+# ---- Load field-level predictions ----
 downscale_preds_csv <- file.path(model_outdir, "downscaled_preds.csv")
 downscale_preds <- vroom::vroom(
   downscale_preds_csv,
   col_types = readr::cols(
+    scenario = readr::col_character(),
     pft = readr::col_character(),
     model_output = readr::col_character(),
     ensemble = readr::col_double(),
@@ -25,77 +42,88 @@ downscale_preds <- vroom::vroom(
   )
 )
 
-ensemble_ids <- unique(downscale_preds$ensemble)
+# Backward compatibility: add scenario column if missing
+if (!"scenario" %in% names(downscale_preds)) {
+  downscale_preds <- downscale_preds |>
+    dplyr::mutate(scenario = "baseline")
+  PEcAn.logger::logger.info("No scenario column found; using 'baseline' for backward compatibility")
+}
 
+ensemble_ids <- unique(downscale_preds$ensemble)
+scenarios <- unique(downscale_preds$scenario)
+
+PEcAn.logger::logger.info(
+  "Loaded predictions: ", nrow(downscale_preds), " rows; ",
+  dplyr::n_distinct(downscale_preds$site_id), " sites; ",
+  length(ensemble_ids), " ensembles; ",
+  length(scenarios), " scenarios"
+)
 
 # For testing, sample predictions evenly across counties and pfts
 if (!PRODUCTION) {
-  # Sample the same site_ids per county across all PFTs
+  # Sample up to 10 site_ids per county (slice_sample handles groups with <10 rows)
   site_sample <- downscale_preds |>
     dplyr::distinct(county, site_id) |>
     dplyr::group_by(county) |>
-    dplyr::slice_sample(n = pmin(10L, dplyr::n())) |>
+    dplyr::slice_sample(n = 10) |>
     dplyr::ungroup()
 
   downscale_preds <- downscale_preds |>
     dplyr::inner_join(site_sample, by = c("county", "site_id"))
 }
 
-### TODO Debug and catch if NAs appears again
+# ---- Check for NA values ----
 na_summary <- downscale_preds |>
   dplyr::summarise(dplyr::across(dplyr::everything(), ~ sum(is.na(.x)))) |>
   tidyr::pivot_longer(dplyr::everything(), names_to = "column", values_to = "n_na") |>
   dplyr::filter(n_na > 0)
 
 if (nrow(na_summary) > 0) {
-  ## concise log message
   PEcAn.logger::logger.warn(
-    "YOU NEED TO DEBUG THIS!!!\n\n",
-    "NA values detected in `downscale_preds`:\n"
+    "NA values detected in `downscale_preds`:\n",
+    paste(capture.output(knitr::kable(na_summary, format = "simple")), collapse = "\n")
   )
-  knitr::kable(na_summary, format = "simple")
-  # remove all rows with NA values
   downscale_preds <- tidyr::drop_na(downscale_preds)
 }
 
+# ---- Aggregate to county level per ensemble ----
 ens_county_preds <- downscale_preds |>
-  # Now aggregate to get county level totals for each pool x ensemble
-  dplyr::group_by(model_output, pft, county, ensemble) |>
+# Now aggregate to get county level totals for each pool x ensemble
+  dplyr::group_by(scenario, model_output, pft, county, ensemble) |>
   dplyr::summarize(
     n = dplyr::n(),
     total_c_Mg = sum(total_c_Mg), # total Mg C per county
     total_ha = sum(area_ha),
     .groups = "drop"
   ) |>
-  # counties with no fields will result in NA below
   dplyr::filter(total_ha > 0) |>
   dplyr::mutate(
     total_c_Tg = PEcAn.utils::ud_convert(total_c_Mg, "Mg", "Tg"),
     c_density_Mg_ha = total_c_Mg / total_ha
   ) |>
-  dplyr::arrange(model_output, pft, county, ensemble)
+  dplyr::arrange(scenario, model_output, pft, county, ensemble)
 
+# ---- Validate ensemble counts ----
 ens_members_by_county <- ens_county_preds |>
-  dplyr::group_by(model_output, pft, county) |>
-  dplyr::summarize(n_vals = dplyr::n_distinct(total_c_Mg), .groups = "drop")
+  dplyr::group_by(scenario, model_output, pft, county) |>
+  dplyr::summarize(n_ens = dplyr::n_distinct(ensemble), .groups = "drop")
 
-if (all(ens_members_by_county$n_vals == length(ensemble_ids))) {
-  PEcAn.logger::logger.info("All counties have the correct number of ensemble members: (", length(ensemble_ids), ")")
+expected_ens <- length(ensemble_ids)
+mismatched <- ens_members_by_county |> dplyr::filter(n_ens != expected_ens)
+if (nrow(mismatched) == 0) {
+  PEcAn.logger::logger.info("All county/scenario combinations have ", expected_ens, " ensemble members")
 } else {
-  z <- ens_members_by_county |>
-    dplyr::group_by(county) |>
-    dplyr::summarise(n = mean(n_vals))
-  PEcAn.logger::logger.error(
-    sum(z$n != length(ensemble_ids)) / length(z$n),
-    "counties have the wrong number of ensemble members after downscaling.",
-    "Check ens_county_preds object."
+  PEcAn.logger::logger.warn(
+    nrow(mismatched), " county/scenario combinations have wrong ensemble count. ",
+    "Expected: ", expected_ens
+
   )
 }
 
+# ---- County summaries (mean/sd across ensembles) ----
 county_summaries <- ens_county_preds |>
-  dplyr::group_by(model_output, pft, county) |>
+  dplyr::group_by(scenario, model_output, pft, county) |>
   dplyr::summarize(
-    # Number of fields in county should be same for each ensemble member
     n = max(n),
     mean_total_c_Tg = mean(total_c_Tg),
     sd_total_c_Tg = sd(total_c_Tg),
@@ -121,19 +149,159 @@ county_summaries <- ens_county_preds |>
     }
   ) |>
   dplyr::mutate(
-    # Only save 3 significant digits
     dplyr::across(
       .cols = c(mean_total_c_Tg, sd_total_c_Tg, mean_c_density_Mg_ha, sd_c_density_Mg_ha),
       .fns = ~ signif(.x, 3)
     )
   )
 
-readr::write_csv(
+write_output(
   county_summaries,
-  file.path(model_outdir, "county_summaries.csv")
+  file.path(model_outdir, "county_aggregated_preds"),
+  "County aggregated predictions"
 )
-PEcAn.logger::logger.info("County summaries written to", file.path(model_outdir, "county_summaries.csv"))
+
+# ---- State-level summaries ----
+state_summaries <- ens_county_preds |>
+  dplyr::group_by(scenario, model_output, pft, ensemble) |>
+  dplyr::summarize(
+    n_counties = dplyr::n_distinct(county),
+    n_fields = sum(n),
+    total_c_Tg = sum(total_c_Tg),
+    total_ha = sum(total_ha),
+    .groups = "drop"
+  ) |>
+  dplyr::group_by(scenario, model_output, pft) |>
+  dplyr::summarize(
+    n_counties = max(n_counties),
+    n_fields = max(n_fields),
+    mean_total_c_Tg = mean(total_c_Tg),
+    sd_total_c_Tg = sd(total_c_Tg),
+    mean_total_ha = mean(total_ha),
+    sd_total_ha = sd(total_ha),
+    .groups = "drop"
+  ) |>
+  dplyr::mutate(
+    mean_c_density_Mg_ha = PEcAn.utils::ud_convert(mean_total_c_Tg, "Tg", "Mg") / mean_total_ha,
+    dplyr::across(
+      .cols = c(mean_total_c_Tg, sd_total_c_Tg),
+      .fns = ~ signif(.x, 3)
+    )
+  )
+
+write_output(
+  state_summaries,
+  file.path(model_outdir, "state_summaries"),
+  "State-level summaries"
+)
+
+# ---- Process deltas ----
+delta_csv <- file.path(model_outdir, "downscaled_deltas.csv")
+if (file.exists(delta_csv)) {
+  PEcAn.logger::logger.info("Processing delta predictions")
+  
+  deltas <- vroom::vroom(
+    delta_csv,
+    col_types = readr::cols(
+      scenario = readr::col_character(),
+      site_id = readr::col_character(),
+      pft = readr::col_character(),
+      ensemble = readr::col_double(),
+      delta_c_density_Mg_ha = readr::col_double(),
+      delta_total_c_Mg = readr::col_double(),
+      area_ha = readr::col_double(),
+      county = readr::col_character(),
+      model_output = readr::col_character()
+    )
+  )
+  
+  # backward compatibility
+  if (!"scenario" %in% names(deltas)) {
+    deltas <- deltas |> dplyr::mutate(scenario = "baseline")
+  }
+  
+  # County-level delta aggregation per ensemble
+  ens_county_deltas <- deltas |>
+    dplyr::group_by(scenario, model_output, pft, county, ensemble) |>
+    dplyr::summarize(
+      n = dplyr::n(),
+      delta_total_Mg = sum(delta_total_c_Mg),
+      total_ha = sum(area_ha),
+      .groups = "drop"
+    ) |>
+    dplyr::filter(total_ha > 0) |>
+    dplyr::mutate(
+      delta_total_Tg = PEcAn.utils::ud_convert(delta_total_Mg, "Mg", "Tg"),
+      delta_density_Mg_ha = delta_total_Mg / total_ha
+    )
+  
+  # Summarize across ensembles
+  county_deltas <- ens_county_deltas |>
+    dplyr::group_by(scenario, model_output, pft, county) |>
+    dplyr::summarize(
+      # Number of fields in county should be same for each ensemble member
+      n = max(n),
+      mean_delta_total_Tg = mean(delta_total_Tg),
+      sd_delta_total_Tg = sd(delta_total_Tg),
+      mean_delta_density_Mg_ha = mean(delta_density_Mg_ha),
+      sd_delta_density_Mg_ha = sd(delta_density_Mg_ha),
+      mean_total_ha = mean(total_ha),
+      .groups = "drop"
+    ) |>
+    dplyr::mutate(
+      # Only save 3 significant digits
+      dplyr::across(
+        .cols = c(mean_delta_total_Tg, sd_delta_total_Tg, mean_delta_density_Mg_ha, sd_delta_density_Mg_ha),
+        .fns = ~ signif(.x, 3)
+      )
+    )
+  
+  write_output(
+    county_deltas,
+    file.path(model_outdir, "county_aggregated_deltas"),
+    "County aggregated deltas"
+  )
+  
+} else {
+  PEcAn.logger::logger.warn("downscaled_deltas.csv not found; skipping delta aggregation")
+}
+
+# ---- Write aggregation metadata ----
+metadata <- list(
+  title = "Aggregated County and State Summaries",
+  description = "SIPNET downscaled outputs aggregated to county and state level",
+  created = Sys.time(),
+  scenarios = scenarios,
+  pfts = unique(county_summaries$pft),
+  outputs = unique(county_summaries$model_output),
+  n_counties = dplyr::n_distinct(county_summaries$county),
+  n_ensembles = length(ensemble_ids),
+  files = list(
+    county_preds = "county_aggregated_preds.csv",
+    county_deltas = if (file.exists(delta_csv)) "county_aggregated_deltas.csv" else NULL,
+    state_summaries = "state_summaries.csv"
+  ),
+  columns = list(
+    scenario = "Management scenario identifier",
+    model_output = "Carbon pool (AGB, TotSoilCarb)",
+    pft = "Plant functional type",
+    county = "California county name",
+    n = "Number of fields",
+    mean_total_c_Tg = "Mean total carbon stock (Tg)",
+    sd_total_c_Tg = "SD of total carbon stock across ensembles",
+    mean_c_density_Mg_ha = "Mean carbon density (Mg/ha)",
+    sd_c_density_Mg_ha = "SD of carbon density across ensembles"
+  )
+)
+
+jsonlite::write_json(
+  metadata,
+  file.path(model_outdir, "aggregation_metadata.json"),
+  pretty = TRUE,
+  auto_unbox = TRUE
+)
+PEcAn.logger::logger.info("Aggregation metadata written to ", file.path(model_outdir, "aggregation_metadata.json"))
 
 PEcAn.logger::logger.info(
-  "Finished aggregation to county level.\n"
+  "Aggregation complete"
 )

--- a/scripts/042_downscale_analysis.R
+++ b/scripts/042_downscale_analysis.R
@@ -222,12 +222,12 @@ for (row in seq_len(nrow(spec_table))) {
   yl <- c(floor(min(y_range)), ceiling(max(y_range)))
 
   randomForest::partialPlot(rf,
-    pred.data = design_covariates, x.var = top_predictors[1], ylim = yl,
+    pred.data = design_covariates, x.var = top_predictors[1],
     main = paste("Partial Dependence -", top_predictors[1]),
     xlab = top_predictors[1], ylab = paste("Predicted", pool, "-", pft_i), col = "steelblue", lwd = 2
   )
   randomForest::partialPlot(rf,
-    pred.data = design_covariates, x.var = top_predictors[2], ylim = yl,
+    pred.data = design_covariates, x.var = top_predictors[2],
     main = paste("Partial Dependence -", top_predictors[2]),
     xlab = top_predictors[2], ylab = paste("Predicted", pool, "-", pft_i), col = "steelblue", lwd = 2
   )

--- a/scripts/043_county_level_plots.R
+++ b/scripts/043_county_level_plots.R
@@ -1,169 +1,83 @@
-## Create county-level plots
-##
-## Usage:
-##   Rscript scripts/043_county_level_plots.R
-##
-## Inputs (from 000-config.R paths):
-##   - model_outdir/out/county_summaries.csv (from 041_aggregate_to_county.R)
-##   - model_outdir/out/downscaled_preds.csv (for mixed-scenario diffs and deltas)
-##   - model_outdir/out/downscaled_deltas.csv (optional; for delta maps)
-##   - data/ca_counties.gpkg (county boundaries)
-##
-## Outputs:
-##   - figures/county_<pft>_<pool>_carbon_{density,stock}.webp
-##   - figures/county_diff_woody_plus_annual_minus_woody_<pool>_carbon_{density,stock}.webp
-##   - figures/county_delta_<pft>_<pool>_carbon_{density,stock}.webp
-##   - Additional poster-grade exports for selected maps (PDF/SVG/PNG)
-##
-## Notes:
-##   - Requires R/ggsave_optimized.R to be sourced via 000-config.R
-##   - Uses facet columns for Mean and SD in each output
+## Create county-level and field-level plots
 source("000-config.R")
-PEcAn.logger::logger.info("Creating county-level plots")
+PEcAn.logger::logger.info("Creating county and field level plots")
+
+# ---- Load data ----
 county_boundaries <- sf::st_read(file.path(data_dir, "ca_counties.gpkg"))
-county_summaries <- readr::read_csv(file = file.path(model_outdir, "county_summaries.csv"))
 
-co_preds_to_plot <- county_summaries |>
+county_summaries <- readr::read_csv(
+  file.path(model_outdir, "county_aggregated_preds.csv"),
+  show_col_types = FALSE
+)
+
+# backward compatibility for scenario column
+if (!"scenario" %in% names(county_summaries)) {
+  county_summaries <- county_summaries |>
+    dplyr::mutate(scenario = "baseline")
+  PEcAn.logger::logger.info("No scenario column found; using 'baseline'")
+}
+
+scenarios <- unique(county_summaries$scenario)
+PEcAn.logger::logger.info("Scenarios to plot: ", paste(scenarios, collapse = ", "))
+
+# ----------County-level STOCK maps----------
+# NOTE: Per CARB request, county-level density choropleth maps are no longer 
+# produced. Density is shown at field level instead.
+
+co_stocks <- county_summaries |>
   dplyr::right_join(county_boundaries, by = "county") |>
-  dplyr::arrange(county, model_output, pft) |>
-  tidyr::pivot_longer(
-    cols = c(mean_total_c_Tg, sd_total_c_Tg, mean_c_density_Mg_ha, sd_c_density_Mg_ha),
-    names_to = "stat",
-    values_to = "value"
-  ) |>
-  dplyr::mutate(
-    units = dplyr::case_when(
-      stringr::str_detect(stat, "total_c") ~ "Carbon Stock (Tg)",
-      stringr::str_detect(stat, "c_density") ~ "Carbon Density (Mg/ha)"
-    ),
-    stat = dplyr::case_when(
-      stringr::str_detect(stat, "mean") ~ "Mean",
-      stringr::str_detect(stat, "sd") ~ "SD"
+  dplyr::filter(!is.na(scenario), !is.na(model_output), !is.na(pft))
+
+combos_stock <- co_stocks |>
+  dplyr::distinct(scenario, pft, model_output) |>
+  dplyr::arrange(scenario, pft, model_output)
+
+PEcAn.logger::logger.info("Creating ", nrow(combos_stock), " county stock maps")
+
+purrr::pwalk(
+  combos_stock,
+  function(scenario, pft, model_output) {
+    dat <- dplyr::filter(
+      co_stocks,
+      scenario == !!scenario,
+      pft == !!pft,
+      model_output == !!model_output
     )
-  )
-
-combos <- co_preds_to_plot |>
-  dplyr::filter(!is.na(model_output), !is.na(pft)) |>
-  dplyr::distinct(pft, model_output, units) |>
-  dplyr::arrange(pft, model_output, units)
-
-# Optional filters via env vars to generate a subset only
-pft_filter   <- Sys.getenv("PFT_FILTER",   unset = "")
-pool_filter  <- Sys.getenv("POOL_FILTER",  unset = "")
-units_filter <- Sys.getenv("UNITS_FILTER", unset = "")
-if (nzchar(pft_filter))   combos <- dplyr::filter(combos, pft == !!pft_filter)
-if (nzchar(pool_filter))  combos <- dplyr::filter(combos, model_output == !!pool_filter)
-if (nzchar(units_filter)) combos <- dplyr::filter(combos, units == !!units_filter)
-
-# Color scale controls
-# Priority: COLOR_SCALE if set -> POSTER_PALETTE if TRUE -> default (plasma)
-use_poster_palette <- isTRUE(as.logical(Sys.getenv("POSTER_PALETTE", "FALSE")))
-color_scale_opt <- tolower(Sys.getenv("COLOR_SCALE", unset = ""))
-custom_colors <- Sys.getenv("CUSTOM_COLORS", unset = "")  # comma-separated hex
-custom_values <- Sys.getenv("CUSTOM_VALUES", unset = "")  # comma-separated numerics in [0,1]
-
-fill_scale <- NULL
-if (nzchar(color_scale_opt)) {
-  if (color_scale_opt %in% c("viridis","plasma","magma","inferno","cividis")) {
-    fill_scale <- ggplot2::scale_fill_viridis_c(option = color_scale_opt, na.value = "white")
-  } else if (color_scale_opt == "custom" && nzchar(custom_colors)) {
-    cols <- trimws(strsplit(custom_colors, ",", fixed = TRUE)[[1]])
-    vals <- if (nzchar(custom_values)) as.numeric(trimws(strsplit(custom_values, ",", fixed = TRUE)[[1]])) else NULL
-    if (is.null(vals)) {
-      fill_scale <- ggplot2::scale_fill_gradientn(colors = cols, na.value = "white")
-    } else {
-      fill_scale <- ggplot2::scale_fill_gradientn(colors = cols, values = vals, na.value = "white")
-    }
-  }
-}
-if (is.null(fill_scale)) {
-  if (use_poster_palette) {
-    # Poster palette requested earlier: light green -> poster green -> poster purple
-    fill_scale <- ggplot2::scale_fill_gradientn(
-      colors = c("#d7f2d3", "#62b874", "#4a2f86"),
-      values = c(0, 0.6, 1),
-      na.value = "white"
-    )
-  } else {
-    fill_scale <- ggplot2::scale_fill_viridis_c(option = "plasma", na.value = "white")
-  }
-}
-
-p <- purrr::pmap(
-  list(combos$pft, combos$model_output, combos$units),
-  function(.pft, pool, unit) {
-    dat <- dplyr::filter(co_preds_to_plot, pft == .pft, model_output == pool, units == unit) |>
-      dplyr::mutate(value_plot = value)
-    .plt <- ggplot2::ggplot(
-      dat,
-      ggplot2::aes(geometry = geom, fill = value_plot)
-    ) +
-      ggplot2::geom_sf(data = county_boundaries, mapping = ggplot2::aes(geometry = geom), fill = "white", color = "black", inherit.aes = FALSE) +
+    
+    p_stock <- ggplot2::ggplot(dat, ggplot2::aes(geometry = geom, fill = mean_total_c_Tg)) +
+      ggplot2::geom_sf(data = county_boundaries, fill = "white", color = "black") +
       ggplot2::geom_sf() +
-      fill_scale +
+      ggplot2::scale_fill_viridis_c(option = "plasma", na.value = "white") +
       ggplot2::theme_minimal() +
-      ggplot2::facet_grid(model_output ~ stat) +
       ggplot2::labs(
-        title = paste("County-Level", pool, "-", .pft),
-        fill = unit
-      ) +
-      ggplot2::guides(fill = ggplot2::guide_colorbar(title.position = "top"))
-
-    unit_key <- ifelse(unit == "Carbon Stock (Tg)", "stock",
-      ifelse(unit == "Carbon Density (Mg/ha)", "density", NA)
-    )
-    pft_key <- stringr::str_replace_all(.pft, "[^A-Za-z0-9]+", "_")
-    plotfile <- here::here("figures", paste0("county_", pft_key, "_", pool, "_carbon_", unit_key, ".webp"))
-    PEcAn.logger::logger.info("Creating county-level plot for", pool, unit, "PFT:", .pft)
+        title = paste("County Carbon Stock:", model_output, "-", pft),
+        subtitle = paste("Scenario:", scenario),
+        fill = "Carbon\nStock (Tg)"
+      )
+    
+    pft_key <- stringr::str_replace_all(pft, "[^A-Za-z0-9]+", "_")
+    scenario_key <- stringr::str_replace_all(scenario, "[^A-Za-z0-9]+", "_")
+    
     ggsave_optimized(
-      filename = plotfile,
-      plot = .plt,
-      width = 10, height = 5, units = "in", dpi = 96,
-      bg = "white"
+      filename = here::here("figures", paste0(
+        "county_", scenario_key, "_", pft_key, "_", model_output, "_carbon_stock.webp"
+      )),
+      plot = p_stock,
+      width = 10, height = 6, units = "in", dpi = 96, bg = "white"
     )
-    # Also export poster-grade formats for the AGB density map of woody perennials
-    if (.pft == "woody perennial crop" && pool == "AGB" && unit_key == "density") {
-      basefile <- here::here("figures", paste0("county_", pft_key, "_", pool, "_carbon_", unit_key))
-      PEcAn.logger::logger.info("Exporting poster-grade versions (28.36x14.18 in):", paste0(basename(basefile), "{.pdf,.svg,.png}"))
-      # Vector formats (preferred for print) at 14.18 in tall (2:1 aspect)
-      ggsave_optimized(filename = paste0(basefile, ".pdf"), plot = .plt, width = 28.36, height = 14.18, units = "in", bg = "white")
-      ggsave_optimized(filename = paste0(basefile, ".svg"), plot = .plt, width = 28.36, height = 14.18, units = "in", bg = "white")
-      # High-resolution raster as fallback
-      ggsave_optimized(filename = paste0(basefile, ".png"), plot = .plt, width = 28.36, height = 14.18, units = "in", dpi = 300, bg = "white")
-    }
-    # High-res PNG for woody perennials SOC stock (12" tall for print)
-    if (.pft == "woody perennial crop" && pool == "TotSoilCarb" && unit_key == "stock") {
-      basefile_soc_stock <- here::here("figures", paste0("county_", pft_key, "_", pool, "_carbon_", unit_key))
-      # Maintain 2:1 aspect (width:height) used above: width=24in, height=12in
-      PEcAn.logger::logger.info("Exporting 12in-tall high-res PNG:", paste0(basename(basefile_soc_stock), ".png"))
-      ggsave_optimized(filename = paste0(basefile_soc_stock, ".png"), plot = .plt,
-                       width = 28.36, height = 14.18, units = "in", dpi = 300, bg = "white")
-    }
-    # High-res exports for annual crop SOC stock
-    if (.pft == "annual crop" && pool == "TotSoilCarb" && unit_key == "stock") {
-      basefile_ann_soc_stock <- here::here("figures", paste0("county_", pft_key, "_", pool, "_carbon_", unit_key))
-      PEcAn.logger::logger.info("Exporting high-res annual SOC stock (28.36x14.18 in):", paste0(basename(basefile_ann_soc_stock), "{.pdf,.png}"))
-      ggsave_optimized(filename = paste0(basefile_ann_soc_stock, ".pdf"), plot = .plt,
-                       width = 28.36, height = 14.18, units = "in", bg = "white")
-      ggsave_optimized(filename = paste0(basefile_ann_soc_stock, ".png"), plot = .plt,
-                       width = 28.36, height = 14.18, units = "in", dpi = 300, bg = "white")
-    }
-    # Export high-res PDF/PNG for County-level woody+herbaceous (mixed) SOC maps
-    if (pool == "TotSoilCarb" && (grepl("woody", .pft, ignore.case = TRUE)) &&
-        (grepl("annual", .pft, ignore.case = TRUE) || grepl("herb", .pft, ignore.case = TRUE))) {
-      basefile_soc <- here::here("figures", paste0("county_", pft_key, "_", pool, "_carbon_", unit_key))
-      PEcAn.logger::logger.info("Exporting high-res SOC versions (28.36x14.18 in):", paste0(basename(basefile_soc), "{.pdf,.png}"))
-      ggsave_optimized(filename = paste0(basefile_soc, ".pdf"), plot = .plt, width = 28.36, height = 14.18, units = "in", bg = "white")
-      ggsave_optimized(filename = paste0(basefile_soc, ".png"), plot = .plt, width = 28.36, height = 14.18, units = "in", dpi = 300, bg = "white")
-    }
-    return(.plt)
+    PEcAn.logger::logger.info("Created stock map: ", scenario, "/", pft, "/", model_output)
   }
 )
 
-## --- County-level differences from matched fields: (woody + annual) minus (woody perennial crop) --- ##
+
+# ----------Field-level density maps----------
+PEcAn.logger::logger.info("Creating field-level density maps")
+
+# Load field-level predictions
 dp <- vroom::vroom(
   file.path(model_outdir, "downscaled_preds.csv"),
   col_types = readr::cols(
+    scenario = readr::col_character(),
     site_id = readr::col_character(),
     pft = readr::col_character(),
     ensemble = readr::col_double(),
@@ -174,79 +88,165 @@ dp <- vroom::vroom(
     model_output = readr::col_character()
   )
 )
+
+if (!"scenario" %in% names(dp)) {
+  dp <- dp |> dplyr::mutate(scenario = "baseline")
+}
+
+# Load field centroids for point maps
+ca_fields <- sf::st_read(file.path(data_dir, "ca_fields.gpkg"))
+field_centroids <- ca_fields |>
+  sf::st_centroid() |>
+  dplyr::select(site_id, geom)
+
+# Compute mean density per field (across ensembles)
+field_mean_density <- dp |>
+  dplyr::group_by(scenario, model_output, pft, site_id) |>
+  dplyr::summarize(
+    mean_c_density_Mg_ha = mean(c_density_Mg_ha, na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  dplyr::inner_join(
+    sf::st_drop_geometry(field_centroids) |> dplyr::select(site_id),
+    by = "site_id"
+  )
+
+# Join with geometry
+field_mean_density_sf <- field_mean_density |>
+  dplyr::inner_join(field_centroids, by = "site_id") |>
+  sf::st_as_sf()
+
+combos_field <- field_mean_density |>
+  dplyr::distinct(scenario, pft, model_output) |>
+  dplyr::arrange(scenario, pft, model_output)
+
+PEcAn.logger::logger.info("Creating ", nrow(combos_field), " field density maps")
+
+purrr::pwalk(
+  combos_field,
+  function(scenario, pft, model_output) {
+    dat <- dplyr::filter(
+      field_mean_density_sf,
+      scenario == !!scenario,
+      pft == !!pft,
+      model_output == !!model_output
+    )
+    
+    p_field <- ggplot2::ggplot() +
+      ggplot2::geom_sf(data = county_boundaries, fill = "gray95", color = "gray70", linewidth = 0.3) +
+      ggplot2::geom_sf(data = dat, ggplot2::aes(color = mean_c_density_Mg_ha), size = 0.4, alpha = 0.7) +
+      ggplot2::scale_color_viridis_c(option = "plasma", na.value = "gray50") +
+      ggplot2::theme_minimal() +
+      ggplot2::labs(
+        title = paste("Field Carbon Density:", model_output, "-", pft),
+        subtitle = paste("Scenario:", scenario),
+        color = "Density\n(Mg/ha)"
+      )
+    
+    pft_key <- stringr::str_replace_all(pft, "[^A-Za-z0-9]+", "_")
+    scenario_key <- stringr::str_replace_all(scenario, "[^A-Za-z0-9]+", "_")
+    
+    ggsave_optimized(
+      filename = here::here("figures", paste0(
+        "field_", scenario_key, "_", pft_key, "_", model_output, "_carbon_density.webp"
+      )),
+      plot = p_field,
+      width = 10, height = 6, units = "in", dpi = 96, bg = "white"
+    )
+    PEcAn.logger::logger.info("Created field density map: ", scenario, "/", pft, "/", model_output)
+  }
+)
+
+# ----------PFT difference maps (woody + annual) minus (woody)----------
+# NOTE: This section only applies to multi-PFT mode, skipped for scenario mode
 mix <- dp |>
-  dplyr::filter(pft == "woody + annual") |>
-  dplyr::select(site_id, ensemble, model_output, county, area_ha_mix = area_ha, total_c_Mg_mix = total_c_Mg)
+  dplyr::filter(pft == "woody + annual")
 wood <- dp |>
-  dplyr::filter(pft == "woody perennial crop") |>
-  dplyr::select(site_id, ensemble, model_output, county, area_ha_woody = area_ha, total_c_Mg_woody = total_c_Mg)
+  dplyr::filter(pft == "woody perennial crop")
 
-# Log if duplicate keys remain (should be rare after upstream normalization)
-mix_dups <- mix |>
-  dplyr::count(site_id, ensemble, model_output, county) |>
-  dplyr::filter(n > 1)
-wood_dups <- wood |>
-  dplyr::count(site_id, ensemble, model_output, county) |>
-  dplyr::filter(n > 1)
-if (nrow(mix_dups) > 0 || nrow(wood_dups) > 0) {
-  PEcAn.logger::logger.severe(paste0(
-    "Duplicate keys detected prior to join (mix=", nrow(mix_dups), ", wood=", nrow(wood_dups), "). ",
-    "Fix upstream duplication; refusing to silently aggregate."
-  ))
+# Only create diff maps if both PFTs exist
+if (nrow(mix) > 0 && nrow(wood) > 0) {
+  PEcAn.logger::logger.info("Creating PFT difference maps (woody+annual - woody)")
+  
+  mix_sel <- mix |>
+    dplyr::select(site_id, ensemble, model_output, county, area_ha_mix = area_ha, total_c_Mg_mix = total_c_Mg)
+  wood_sel <- wood |>
+    dplyr::select(site_id, ensemble, model_output, county, area_ha_woody = area_ha, total_c_Mg_woody = total_c_Mg)
+  
+  # Check for duplicates
+ mix_dups <- mix_sel |>
+    dplyr::count(site_id, ensemble, model_output, county) |>
+    dplyr::filter(n > 1)
+  wood_dups <- wood_sel |>
+    dplyr::count(site_id, ensemble, model_output, county) |>
+    dplyr::filter(n > 1)
+  
+  if (nrow(mix_dups) > 0 || nrow(wood_dups) > 0) {
+    PEcAn.logger::logger.warn(
+      "Duplicate keys detected (mix=", nrow(mix_dups), ", wood=", nrow(wood_dups), "); skipping diff maps"
+    )
+  } else {
+    diff_county <- mix_sel |>
+      dplyr::inner_join(wood_sel, by = c("site_id", "ensemble", "model_output", "county")) |>
+      dplyr::mutate(
+        diff_total_Mg = total_c_Mg_mix - total_c_Mg_woody,
+        area_ha = dplyr::coalesce(area_ha_woody, area_ha_mix)
+      ) |>
+      dplyr::group_by(county, model_output, ensemble) |>
+      dplyr::summarise(diff_total_Mg = sum(diff_total_Mg), total_ha = sum(area_ha), .groups = "drop") |>
+      dplyr::mutate(
+        diff_total_Tg = PEcAn.utils::ud_convert(diff_total_Mg, "Mg", "Tg"),
+        diff_density_Mg_ha = diff_total_Mg / total_ha
+      ) |>
+      dplyr::group_by(county, model_output) |>
+      dplyr::summarise(
+        mean_diff_total_Tg = mean(diff_total_Tg),
+        mean_diff_density_Mg_ha = mean(diff_density_Mg_ha),
+        .groups = "drop"
+      ) |>
+      dplyr::right_join(county_boundaries, by = "county")
+    
+    for (pool in unique(stats::na.omit(diff_county$model_output))) {
+      dat_pool <- dplyr::filter(diff_county, model_output == pool)
+      
+      # Stock difference map only (density removed per CARB)
+      p_stock <- ggplot2::ggplot(dat_pool, ggplot2::aes(geometry = geom, fill = mean_diff_total_Tg)) +
+        ggplot2::geom_sf(data = county_boundaries, fill = "white", color = "black") +
+        ggplot2::geom_sf() +
+        ggplot2::scale_fill_gradient2(
+          low = "royalblue", mid = "white", high = "firebrick",
+          midpoint = 0, na.value = "white"
+        ) +
+        ggplot2::theme_minimal() +
+        ggplot2::labs(
+          title = paste("Difference in Carbon Stock: (woody + annual) - (woody)"),
+          subtitle = pool,
+          fill = "Delta (Tg)"
+        )
+      
+      ggsave_optimized(
+        filename = here::here("figures", paste0(
+          "county_diff_woody_plus_annual_minus_woody_", pool, "_carbon_stock.webp"
+        )),
+        plot = p_stock,
+        width = 10, height = 6, units = "in", dpi = 96, bg = "white"
+      )
+    }
+  }
+} else {
+  PEcAn.logger::logger.info("Skipping PFT diff maps (woody + annual or woody perennial not present)")
 }
 
-diff_county <- mix |>
-  dplyr::inner_join(wood, by = c("site_id", "ensemble", "model_output", "county")) |>
-  dplyr::mutate(diff_total_Mg = total_c_Mg_mix - total_c_Mg_woody, area_ha = dplyr::coalesce(area_ha_woody, area_ha_mix)) |>
-  dplyr::group_by(county, model_output, ensemble) |>
-  dplyr::summarise(diff_total_Mg = sum(diff_total_Mg), total_ha = sum(area_ha), .groups = "drop") |>
-  dplyr::mutate(diff_total_Tg = PEcAn.utils::ud_convert(diff_total_Mg, "Mg", "Tg"), diff_density_Mg_ha = diff_total_Mg / total_ha) |>
-  dplyr::group_by(county, model_output) |>
-  dplyr::summarise(mean_diff_total_Tg = mean(diff_total_Tg), mean_diff_density_Mg_ha = mean(diff_density_Mg_ha), .groups = "drop") |>
-  dplyr::right_join(county_boundaries, by = "county")
 
-for (pool in unique(stats::na.omit(diff_county$model_output))) {
-  dat_pool <- dplyr::filter(diff_county, model_output == pool)
-
-  # Density difference map (Mg/ha)
-  p_density <- ggplot2::ggplot(dat_pool, ggplot2::aes(geometry = geom, fill = mean_diff_density_Mg_ha)) +
-    ggplot2::geom_sf(data = county_boundaries, fill = "white", color = "black") +
-    ggplot2::geom_sf() +
-    ggplot2::scale_fill_gradient2(low = "royalblue", mid = "white", high = "firebrick", midpoint = 0, na.value = "white") +
-    ggplot2::theme_minimal() +
-    ggplot2::labs(
-      title = paste("Difference in Carbon Density (Mg/ha): (woody + annual) - (woody)", pool),
-      fill = "Delta (Mg/ha)"
-    )
-  ggsave_optimized(
-    filename = here::here("figures", paste0("county_diff_woody_plus_annual_minus_woody_", pool, "_carbon_density.webp")),
-    plot = p_density,
-    width = 10, height = 5, units = "in", dpi = 96, bg = "white"
-  )
-
-  # Stock difference map (Tg)
-  p_stock <- ggplot2::ggplot(dat_pool, ggplot2::aes(geometry = geom, fill = mean_diff_total_Tg)) +
-    ggplot2::geom_sf(data = county_boundaries, fill = "white", color = "black") +
-    ggplot2::geom_sf() +
-    ggplot2::scale_fill_gradient2(low = "royalblue", mid = "white", high = "firebrick", midpoint = 0, na.value = "white") +
-    ggplot2::theme_minimal() +
-    ggplot2::labs(
-      title = paste("Difference in Carbon Stock (Tg): (woody + annual) - (woody)", pool),
-      fill = "Delta (Tg)"
-    )
-  ggsave_optimized(
-    filename = here::here("figures", paste0("county_diff_woody_plus_annual_minus_woody_", pool, "_carbon_stock.webp")),
-    plot = p_stock,
-    width = 10, height = 5, units = "in", dpi = 96, bg = "white"
-  )
-}
-
-## --- County-level deltas: start->end for woody and annual --- ##
+## --- County-level deltas: start->end carbon change for all PFTs and scenarios --- ##
 delta_csv <- file.path(model_outdir, "downscaled_deltas.csv")
 if (file.exists(delta_csv)) {
+  PEcAn.logger::logger.info("Creating delta maps")
+  
   deltas <- vroom::vroom(
     delta_csv,
     col_types = readr::cols(
+      scenario = readr::col_character(),
       site_id = readr::col_character(),
       pft = readr::col_character(),
       ensemble = readr::col_double(),
@@ -257,58 +257,74 @@ if (file.exists(delta_csv)) {
       model_output = readr::col_character()
     )
   )
-
+  
+  if (!"scenario" %in% names(deltas)) {
+    deltas <- deltas |> dplyr::mutate(scenario = "baseline")
+  }
+  
   delta_county <- deltas |>
-    dplyr::group_by(model_output, pft, county, ensemble) |>
-    dplyr::summarize(total_delta_Mg = sum(delta_total_c_Mg), total_ha = sum(area_ha), .groups = "drop") |>
+    dplyr::group_by(scenario, model_output, pft, county, ensemble) |>
+    dplyr::summarize(
+      total_delta_Mg = sum(delta_total_c_Mg),
+      total_ha = sum(area_ha),
+      .groups = "drop"
+    ) |>
     dplyr::mutate(
       delta_density_Mg_ha = total_delta_Mg / total_ha,
       delta_total_Tg = PEcAn.utils::ud_convert(total_delta_Mg, "Mg", "Tg")
     ) |>
-    dplyr::group_by(model_output, pft, county) |>
+    dplyr::group_by(scenario, model_output, pft, county) |>
     dplyr::summarize(
       mean_delta_density_Mg_ha = mean(delta_density_Mg_ha),
       mean_delta_total_Tg = mean(delta_total_Tg),
       .groups = "drop"
     ) |>
     dplyr::right_join(county_boundaries, by = "county")
-
+  
   combos_delta <- delta_county |>
-    dplyr::filter(!is.na(model_output), !is.na(pft)) |>
-    dplyr::distinct(pft, model_output)
-
+    dplyr::filter(!is.na(scenario), !is.na(model_output), !is.na(pft)) |>
+    dplyr::distinct(scenario, pft, model_output)
+  
   purrr::pwalk(
     combos_delta,
-    function(pft, model_output) {
-      datp <- dplyr::filter(delta_county, pft == !!pft, model_output == !!model_output)
-      pft_key <- stringr::str_replace_all(pft, "[^A-Za-z0-9]+", "_")
-      # density
-      p_den <- ggplot2::ggplot(datp, ggplot2::aes(geometry = geom, fill = mean_delta_density_Mg_ha)) +
-        ggplot2::geom_sf(data = county_boundaries, fill = "white", color = "black") +
-        ggplot2::geom_sf() +
-        ggplot2::scale_fill_gradient2(low = "royalblue", mid = "white", high = "firebrick", midpoint = 0, na.value = "white") +
-        ggplot2::theme_minimal() +
-        ggplot2::labs(
-          title = paste("Delta Density (start->end)", model_output, "-", pft),
-          fill = "Delta (Mg/ha)"
-        )
-      ggsave_optimized(
-        filename = here::here("figures", paste0("county_delta_", pft_key, "_", model_output, "_carbon_density.webp")),
-        plot = p_den, width = 10, height = 5, units = "in", dpi = 96, bg = "white"
+    function(scenario, pft, model_output) {
+      datp <- dplyr::filter(
+        delta_county,
+        scenario == !!scenario,
+        pft == !!pft,
+        model_output == !!model_output
       )
-      # stock
+      
+      pft_key <- stringr::str_replace_all(pft, "[^A-Za-z0-9]+", "_")
+      scenario_key <- stringr::str_replace_all(scenario, "[^A-Za-z0-9]+", "_")
+      
+      # Stock delta map only (per CARB - no county density)
       p_stk <- ggplot2::ggplot(datp, ggplot2::aes(geometry = geom, fill = mean_delta_total_Tg)) +
         ggplot2::geom_sf(data = county_boundaries, fill = "white", color = "black") +
         ggplot2::geom_sf() +
-        ggplot2::scale_fill_gradient2(low = "royalblue", mid = "white", high = "firebrick", midpoint = 0, na.value = "white") +
+        ggplot2::scale_fill_gradient2(
+          low = "royalblue", mid = "white", high = "firebrick",
+          midpoint = 0, na.value = "white"
+        ) +
         ggplot2::theme_minimal() +
         ggplot2::labs(
-          title = paste("Delta Stock (start->end)", model_output, "-", pft),
+          title = paste("Delta Stock (start->end):", model_output, "-", pft),
+          subtitle = paste("Scenario:", scenario),
           fill = "Delta (Tg)"
         )
-      ggsave_optimized(filename = here::here("figures", paste0("county_delta_", pft_key, "_", model_output, "_carbon_stock.webp")), plot = p_stk, width = 10, height = 5, units = "in", dpi = 96, bg = "white")
+      
+      ggsave_optimized(
+        filename = here::here("figures", paste0(
+          "county_delta_", scenario_key, "_", pft_key, "_", model_output, "_carbon_stock.webp"
+        )),
+        plot = p_stk,
+        width = 10, height = 6, units = "in", dpi = 96, bg = "white"
+      )
+      PEcAn.logger::logger.info("Created delta map: ", scenario, "/", pft, "/", model_output)
     }
   )
 } else {
   PEcAn.logger::logger.warn("downscaled_deltas.csv not found; skipping delta maps")
 }
+
+PEcAn.logger::logger.info("Finished creating all plots")

--- a/scripts/043_county_level_plots.R
+++ b/scripts/043_county_level_plots.R
@@ -21,7 +21,7 @@ scenarios <- unique(county_summaries$scenario)
 PEcAn.logger::logger.info("Scenarios to plot: ", paste(scenarios, collapse = ", "))
 
 # ----------County-level STOCK maps----------
-# NOTE: Per CARB request, county-level density choropleth maps are no longer 
+# NOTE: Per CARB request, county-level density choropleth maps are no longer
 # produced. Density is shown at field level instead.
 
 co_stocks <- county_summaries |>
@@ -174,7 +174,7 @@ if (nrow(mix) > 0 && nrow(wood) > 0) {
     dplyr::select(site_id, ensemble, model_output, county, area_ha_woody = area_ha, total_c_Mg_woody = total_c_Mg)
   
   # Check for duplicates
- mix_dups <- mix_sel |>
+  mix_dups <- mix_sel |>
     dplyr::count(site_id, ensemble, model_output, county) |>
     dplyr::filter(n > 1)
   wood_dups <- wood_sel |>


### PR DESCRIPTION
### Summary

Implements county- and state-level aggregation for management scenario outputs, completing the downscaling workflow for Phase 3 scenario analysis. Includes visualisation updates .

Closes [#168](https://github.com/ccmmf/organization/issues/168)

### Changes

**`041_aggregate_to_county.R`**
- Aggregates field-level predictions to county level by scenario, PFT, and carbon pool
- Generates state-level summaries (California totals) per scenario
- Processes delta predictions (start->end carbon change) with scenario grouping
- Outputs: `county_aggregated_preds.csv`, `county_aggregated_deltas.csv`, `state_summaries.csv`, `aggregation_metadata.json`

**`043_county_level_plots.R`** 
- County stock maps now include scenario in filename and subtitle
- Removed county-level density choropleth maps (per CARB: difficult to interpret at county scale)
- Added field-level point maps showing carbon density per field (more informative spatial granularity)
- Delta maps updated with scenario awareness

**Documentation:**
- Updated `docs/workflow_documentation.md` with new output file descriptions
- Updated `docs/CHANGELOG.md`
### Dependencies

- Requires outputs from [#167](https://github.com/ccmmf/organization/issues/167) (`downscaled_preds.csv`, `downscaled_deltas.csv`)