### PR TITLE
Downscale N2O and CH4 flux variables

### DIFF
--- a/000-config.R
+++ b/000-config.R
@@ -37,7 +37,7 @@ pecan_archive_tgz <- file.path(ccmmf_dir, "lebauer_agu_2025_20251210.tgz")
 
 # **Variables to extract**
 # see docs/workflow_documentation.qmd for complete list of outputs
-outputs_to_extract <- c("TotSoilCarb", "AGB")
+outputs_to_extract <- c("TotSoilCarb", "AGB", "N2O_flux", "CH4_flux")
 if (!PRODUCTION) {
   # can subset for testing
   # depending on what part of the workflow you are testing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,12 +6,14 @@ Once a new release is made this file will be updated to create a new `Unreleased
 
 For more information about this file see also [Keep a Changelog](http://keepachangelog.com/) .
 
-<!-- 
+
 sections to include in release notes:
 
 ## [Unreleased]
 
 ### Added
+
+- Support for N2O and CH4 flux variables throughout the downscaling pipeline (#11)
 
 ### Fixed
 
@@ -19,7 +21,7 @@ sections to include in release notes:
 
 ### Removed
 
--->
+
 
 ## 0.2.0-2a
 

--- a/scripts/030_extract_sipnet_output.R
+++ b/scripts/030_extract_sipnet_output.R
@@ -173,12 +173,11 @@ ens_results <- ens_results |>
         .groups = "drop"
     )
 
-# Warn if flux variables are present because users may need to treat them differently.
 if (any(ens_results$variable_type == "flux")) {
-    PEcAn.logger::logger.severe(
-        "Flux variables detected in ensemble output. Note: averaging flux (rate) variables",
-        "across ensembles/sites or over time can be misleading. Consider computing cumulative",
-        "fluxes over simulation period",
+    PEcAn.logger::logger.info(
+        "Flux variables detected in ensemble output. Monthly means of instantaneous",
+        "rates (e.g. kg m-2 s-1) are valid mean rates. Downstream scripts handle",
+        "unit conversion to reporting units (e.g. kg ha-1 yr-1)."
     )
 }
 

--- a/scripts/031_aggregate_sipnet_output.R
+++ b/scripts/031_aggregate_sipnet_output.R
@@ -20,7 +20,7 @@ PEcAn.logger::logger.info("*** Starting multi-PFT aggregation ***")
 
 # ---- Load ensemble output ----------------------------------------------------
 ensemble_output_csv <- file.path(model_outdir, "ensemble_output.csv")
-ensemble_data <- readr::read_csv(ensemble_output_csv) |>
+ensemble_data_all <- readr::read_csv(ensemble_output_csv) |>
   # rename EFI std names for clarity
   # efi name   | new name
   # parameter  | ensemble_id
@@ -28,8 +28,26 @@ ensemble_data <- readr::read_csv(ensemble_output_csv) |>
   dplyr::rename(
     ensemble_id = parameter,
     value = prediction
-  ) |>
-  dplyr::filter(variable %in% c("AGB", "TotSoilCarb"))
+  )
+
+std_vars <- PEcAn.utils::standard_vars
+pool_var_names <- std_vars |>
+  dplyr::filter(stringr::str_detect(tolower(Category), "pool")) |>
+  dplyr::pull(Variable.Name)
+
+# pools go through multi-PFT mixing; fluxes pass through unchanged
+pool_vars_present <- intersect(unique(ensemble_data_all$variable), pool_var_names)
+flux_vars_present <- setdiff(unique(ensemble_data_all$variable), pool_var_names)
+
+if (length(flux_vars_present) > 0) {
+  PEcAn.logger::logger.info(
+    "Flux variables (", paste(flux_vars_present, collapse = ", "),
+    ") will bypass multi-PFT mixing and pass through unchanged."
+  )
+}
+
+ensemble_data <- ensemble_data_all |>
+  dplyr::filter(variable %in% pool_vars_present)
 
 # ---- Load or build cover fractions for each year -----------------------------
 
@@ -229,4 +247,16 @@ mixed_output_csv <- file.path(model_outdir, "ensemble_output_with_mixed.csv")
 readr::write_csv(ensemble_with_mixed, mixed_output_csv)
 PEcAn.logger::logger.info("Wrote EFI-compliant ensemble with mixed PFT: ", mixed_output_csv)
 
+# flux rates are per-PFT values; mixing gas emissions across overlapping PFTs
+# is not physically meaningful in the same way as stock mixing
+if (length(flux_vars_present) > 0) {
+  flux_data <- ensemble_data_all |>
+    dplyr::filter(variable %in% flux_vars_present) |>
+    dplyr::rename(parameter = ensemble_id, prediction = value)
+
+  ensemble_with_mixed <- dplyr::bind_rows(ensemble_with_mixed, flux_data)
+  # re-write the CSV so it includes the flux rows
+  readr::write_csv(ensemble_with_mixed, mixed_output_csv)
+  PEcAn.logger::logger.info("Updated EFI-compliant ensemble with flux data: ", mixed_output_csv)
+}
 PEcAn.logger::logger.info("*** Finished two-PFT aggregation ***")

--- a/scripts/040_downscale.R
+++ b/scripts/040_downscale.R
@@ -174,6 +174,29 @@ extract_oob_r2 <- function(model, y_train = NULL) {
   NA_real_
 }
 
+# ---- unit-conversion helper -------------------------------------------------
+#' convert model predictions from native units to reporting units.
+#' pools (kg/m2) -> Mg/ha; Fluxes (kg/m2/s) -> kg/ha/yr.
+convert_to_reporting_units <- function(prediction, model_output) {
+  std_vars <- PEcAn.utils::standard_vars
+  
+  # determine which model_output values are fluxes
+  flux_vars <- std_vars |>
+    dplyr::filter(stringr::str_detect(tolower(Category), "flux")) |>
+    dplyr::pull(Variable.Name)
+  
+  is_flux <- model_output %in% flux_vars
+  
+  seconds_per_year <- 365.25 * 86400
+  m2_per_ha <- 1e4
+  
+  dplyr::if_else(
+    is_flux,
+    prediction * seconds_per_year * m2_per_ha,        # kg/m2/s -> kg/ha/yr
+    PEcAn.utils::ud_convert(prediction, "kg/m2", "Mg/ha")  # kg/m2 -> Mg/ha
+  )
+}
+
 # ----define design points based on ensemble data-------------------------------
 # TODO: move this sanitization upstream to when ens data is created (030_extract_sipnet_output.R)
 # or better ... figure out why we so often run into mis-match!!!
@@ -549,10 +572,10 @@ for (pool in outputs_to_extract) {
         dplyr::mutate(
           pft = pft_i,
           model_output = pool,
-          delta_c_density_Mg_ha = PEcAn.utils::ud_convert(delta_pred, "kg/m2", "Mg/ha"),
-          delta_total_c_Mg = delta_c_density_Mg_ha * area_ha
+          delta_density_per_ha = convert_to_reporting_units(delta_pred, pool),
+          delta_total = delta_density_per_ha * area_ha
         ) |>
-        dplyr::select(site_id, pft, ensemble, delta_c_density_Mg_ha, delta_total_c_Mg, area_ha, county, model_output)
+        dplyr::select(site_id, pft, ensemble, delta_density_per_ha, delta_total, area_ha, county, model_output)
       delta_output_records[[paste0(pft_i, "::", pool)]] <- delta_df
     }
 
@@ -643,16 +666,14 @@ downscale_preds <- purrr::map(downscale_output_list, get_downscale_preds) |>
     sep = "::",
     remove = TRUE
   ) |>
-  # Convert kg/m2 to Mg/ha using PEcAn.utils::ud_convert
-  dplyr::mutate(c_density_Mg_ha = PEcAn.utils::ud_convert(prediction, "kg/m2", "Mg/ha")) |>
-  # Calculate total Mg per field: c_density_Mg_ha * area_ha
-  dplyr::mutate(total_c_Mg = c_density_Mg_ha * area_ha) |>
-  dplyr::select(site_id, pft, ensemble, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output, -prediction)
+  dplyr::mutate(density_per_ha = convert_to_reporting_units(prediction, model_output)) |>
+  dplyr::mutate(total_per_field = density_per_ha * area_ha) |>
+  dplyr::select(site_id, pft, ensemble, density_per_ha, total_per_field, area_ha, county, model_output, -prediction)
 
 dp <- downscale_preds |>
   dplyr::select(
     site_id, pft, ensemble,
-    c_density_Mg_ha, total_c_Mg,
+    density_per_ha, total_per_field,
     area_ha, county, model_output
   )
 
@@ -785,10 +806,10 @@ if (length(target_woody_sites) == 0) {
       dplyr::mutate(
         pft = "woody + annual",
         model_output = pool,
-        c_density_Mg_ha = PEcAn.utils::ud_convert(mixed_pred, "kg/m2", "Mg/ha"),
-        total_c_Mg = c_density_Mg_ha * area_ha
+        density_per_ha = convert_to_reporting_units(mixed_pred, pool),
+        total_per_field = density_per_ha * area_ha
       ) |>
-      dplyr::select(site_id, pft, ensemble, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
+      dplyr::select(site_id, pft, ensemble, density_per_ha, total_per_field, area_ha, county, model_output)
 
     mixed_records[[pool]] <- mix_df
 
@@ -799,10 +820,10 @@ if (length(target_woody_sites) == 0) {
         pft = pft_i,
         model_output = pool,
         scenario = "woody_100",
-        c_density_Mg_ha = PEcAn.utils::ud_convert(woody_pred, "kg/m2", "Mg/ha"),
-        total_c_Mg = c_density_Mg_ha * area_ha
+        density_per_ha = convert_to_reporting_units(woody_pred, pool),
+        total_per_field = density_per_ha * area_ha
       ) |>
-      dplyr::select(site_id, pft, ensemble, scenario, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
+      dplyr::select(site_id, pft, ensemble, scenario, density_per_ha, total_per_field, area_ha, county, model_output)
 
     annual_scn <- ann_end_df |>
       dplyr::left_join(ca_fields, by = "site_id") |>
@@ -810,14 +831,14 @@ if (length(target_woody_sites) == 0) {
         pft = pft_i,
         model_output = pool,
         scenario = "annual_100",
-        c_density_Mg_ha = PEcAn.utils::ud_convert(annual_end, "kg/m2", "Mg/ha"),
-        total_c_Mg = c_density_Mg_ha * area_ha
+        density_per_ha = convert_to_reporting_units(annual_end, pool),
+        total_per_field = density_per_ha * area_ha
       ) |>
-      dplyr::select(site_id, pft, ensemble, scenario, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
+      dplyr::select(site_id, pft, ensemble, scenario, density_per_ha, total_per_field, area_ha, county, model_output)
 
     mixed_scn <- mix_df |>
       dplyr::mutate(scenario = "woody_50_annual_50") |>
-      dplyr::select(site_id, pft, ensemble, scenario, c_density_Mg_ha, total_c_Mg, area_ha, county, model_output)
+      dplyr::select(site_id, pft, ensemble, scenario, density_per_ha, total_per_field, area_ha, county, model_output)
 
     # accumulate
     if (!exists("treatment_records", inherits = FALSE)) treatment_records <- list()
@@ -861,11 +882,11 @@ metadata <- list(
     site_id = "Unique identifier for each field from LandIQ",
     pft = "Plant functional type",
     ensemble = "Ensemble member identifier",
-    c_density_Mg_ha = "Predicted carbon density (Mg/ha)",
-    total_c_Mg = "Predicted total carbon (Mg) per field",
+    density_per_ha = "Predicted density per hectare: Mg/ha for pools, kg/ha/yr for fluxes",
+    total_per_field = "Predicted total per field: density_per_ha * area_ha",
     area_ha = "Field area in hectares",
     county = "California county name where the field is located",
-    model_output = "Type of SIPNET model output (e.g., AGB, TotSoilCarb)"
+    model_output = "Type of SIPNET model output (e.g., AGB, TotSoilCarb, N2O_flux, CH4_flux)"
   )
 )
 

--- a/scripts/041_aggregate_to_county.R
+++ b/scripts/041_aggregate_to_county.R
@@ -20,8 +20,8 @@ downscale_preds <- vroom::vroom(
     site_id = readr::col_character(),
     county = readr::col_character(),
     area_ha = readr::col_double(),
-    c_density_Mg_ha = readr::col_double(),
-    total_c_Mg = readr::col_double()
+    density_per_ha = readr::col_double(),
+    total_per_field = readr::col_double()
   )
 )
 
@@ -59,25 +59,22 @@ if (nrow(na_summary) > 0) {
 }
 
 ens_county_preds <- downscale_preds |>
-  # Now aggregate to get county level totals for each pool x ensemble
   dplyr::group_by(model_output, pft, county, ensemble) |>
   dplyr::summarize(
     n = dplyr::n(),
-    total_c_Mg = sum(total_c_Mg), # total Mg C per county
+    total_per_county = sum(total_per_field),
     total_ha = sum(area_ha),
     .groups = "drop"
   ) |>
-  # counties with no fields will result in NA below
   dplyr::filter(total_ha > 0) |>
   dplyr::mutate(
-    total_c_Tg = PEcAn.utils::ud_convert(total_c_Mg, "Mg", "Tg"),
-    c_density_Mg_ha = total_c_Mg / total_ha
+    density_per_ha = total_per_county / total_ha
   ) |>
   dplyr::arrange(model_output, pft, county, ensemble)
 
 ens_members_by_county <- ens_county_preds |>
   dplyr::group_by(model_output, pft, county) |>
-  dplyr::summarize(n_vals = dplyr::n_distinct(total_c_Mg), .groups = "drop")
+  dplyr::summarize(n_vals = dplyr::n_distinct(total_per_county), .groups = "drop")
 
 if (all(ens_members_by_county$n_vals == length(ensemble_ids))) {
   PEcAn.logger::logger.info("All counties have the correct number of ensemble members: (", length(ensemble_ids), ")")
@@ -95,12 +92,11 @@ if (all(ens_members_by_county$n_vals == length(ensemble_ids))) {
 county_summaries <- ens_county_preds |>
   dplyr::group_by(model_output, pft, county) |>
   dplyr::summarize(
-    # Number of fields in county should be same for each ensemble member
     n = max(n),
-    mean_total_c_Tg = mean(total_c_Tg),
-    sd_total_c_Tg = sd(total_c_Tg),
-    mean_c_density_Mg_ha = mean(c_density_Mg_ha),
-    sd_c_density_Mg_ha = sd(c_density_Mg_ha),
+    mean_total_per_county = mean(total_per_county),
+    sd_total_per_county = sd(total_per_county),
+    mean_density_per_ha = mean(density_per_ha),
+    sd_density_per_ha = sd(density_per_ha),
     mean_total_ha = mean(total_ha),
     sd_total_ha = sd(total_ha),
     .groups = "drop"
@@ -112,18 +108,17 @@ county_summaries <- ens_county_preds |>
           "At least one (model_output, pft, county) group has n == 1; variability across ensembles cannot be assessed."
         )
       }
-      if (any(df$sd_total_c_Tg == 0, na.rm = TRUE)) {
+      if (any(df$sd_total_per_county == 0, na.rm = TRUE)) {
         PEcAn.logger::logger.severe(
-          "At least one (model_output, pft, county) group has zero variability across ensembles (sd_total_c_Tg == 0)."
+          "At least one (model_output, pft, county) group has zero variability across ensembles (sd_total_per_county == 0)."
         )
       }
       df
     }
   ) |>
   dplyr::mutate(
-    # Only save 3 significant digits
     dplyr::across(
-      .cols = c(mean_total_c_Tg, sd_total_c_Tg, mean_c_density_Mg_ha, sd_c_density_Mg_ha),
+      .cols = c(mean_total_per_county, sd_total_per_county, mean_density_per_ha, sd_density_per_ha),
       .fns = ~ signif(.x, 3)
     )
   )

--- a/scripts/042_downscale_analysis.R
+++ b/scripts/042_downscale_analysis.R
@@ -12,8 +12,8 @@ downscale_preds <- vroom::vroom(
     site_id = readr::col_character(),
     pft = readr::col_character(),
     ensemble = readr::col_double(),
-    c_density_Mg_ha = readr::col_double(),
-    total_c_Mg = readr::col_double(),
+    density_per_ha = readr::col_double(),
+    total_per_field = readr::col_double(),
     area_ha = readr::col_double(),
     county = readr::col_character(),
     model_output = readr::col_character()
@@ -35,7 +35,7 @@ PEcAn.logger::logger.info("Number of numeric predictors:", length(covariate_name
 
 preds_join <- downscale_preds |>
   dplyr::left_join(covariates, by = "site_id") |>
-  tidyr::drop_na(c_density_Mg_ha)
+  tidyr::drop_na(density_per_ha)
 
 # Optional: load training site metadata
 train_sites_csv <- file.path(model_outdir, "training_sites.csv")

--- a/scripts/043_county_level_plots.R
+++ b/scripts/043_county_level_plots.R
@@ -27,14 +27,14 @@ co_preds_to_plot <- county_summaries |>
   dplyr::right_join(county_boundaries, by = "county") |>
   dplyr::arrange(county, model_output, pft) |>
   tidyr::pivot_longer(
-    cols = c(mean_total_c_Tg, sd_total_c_Tg, mean_c_density_Mg_ha, sd_c_density_Mg_ha),
+    cols = c(mean_total_per_county, sd_total_per_county, mean_density_per_ha, sd_density_per_ha),
     names_to = "stat",
     values_to = "value"
   ) |>
   dplyr::mutate(
     units = dplyr::case_when(
-      stringr::str_detect(stat, "total_c") ~ "Carbon Stock (Tg)",
-      stringr::str_detect(stat, "c_density") ~ "Carbon Density (Mg/ha)"
+      stringr::str_detect(stat, "total_per_county") ~ "Total per County",
+      stringr::str_detect(stat, "density_per_ha") ~ "Density per Hectare"
     ),
     stat = dplyr::case_when(
       stringr::str_detect(stat, "mean") ~ "Mean",
@@ -109,8 +109,8 @@ p <- purrr::pmap(
       ) +
       ggplot2::guides(fill = ggplot2::guide_colorbar(title.position = "top"))
 
-    unit_key <- ifelse(unit == "Carbon Stock (Tg)", "stock",
-      ifelse(unit == "Carbon Density (Mg/ha)", "density", NA)
+    unit_key <- ifelse(unit == "Total per County", "stock",
+      ifelse(unit == "Density per Hectare", "density", NA)
     )
     pft_key <- stringr::str_replace_all(.pft, "[^A-Za-z0-9]+", "_")
     plotfile <- here::here("figures", paste0("county_", pft_key, "_", pool, "_carbon_", unit_key, ".webp"))
@@ -167,8 +167,8 @@ dp <- vroom::vroom(
     site_id = readr::col_character(),
     pft = readr::col_character(),
     ensemble = readr::col_double(),
-    c_density_Mg_ha = readr::col_double(),
-    total_c_Mg = readr::col_double(),
+    density_per_ha = readr::col_double(),
+    total_per_field = readr::col_double(),
     area_ha = readr::col_double(),
     county = readr::col_character(),
     model_output = readr::col_character()
@@ -176,10 +176,10 @@ dp <- vroom::vroom(
 )
 mix <- dp |>
   dplyr::filter(pft == "woody + annual") |>
-  dplyr::select(site_id, ensemble, model_output, county, area_ha_mix = area_ha, total_c_Mg_mix = total_c_Mg)
+  dplyr::select(site_id, ensemble, model_output, county, area_ha_mix = area_ha, total_mix = total_per_field)
 wood <- dp |>
   dplyr::filter(pft == "woody perennial crop") |>
-  dplyr::select(site_id, ensemble, model_output, county, area_ha_woody = area_ha, total_c_Mg_woody = total_c_Mg)
+  dplyr::select(site_id, ensemble, model_output, county, area_ha_woody = area_ha, total_woody = total_per_field)
 
 # Log if duplicate keys remain (should be rare after upstream normalization)
 mix_dups <- mix |>
@@ -197,26 +197,26 @@ if (nrow(mix_dups) > 0 || nrow(wood_dups) > 0) {
 
 diff_county <- mix |>
   dplyr::inner_join(wood, by = c("site_id", "ensemble", "model_output", "county")) |>
-  dplyr::mutate(diff_total_Mg = total_c_Mg_mix - total_c_Mg_woody, area_ha = dplyr::coalesce(area_ha_woody, area_ha_mix)) |>
+  dplyr::mutate(diff_total = total_mix - total_woody, area_ha = dplyr::coalesce(area_ha_woody, area_ha_mix)) |>
   dplyr::group_by(county, model_output, ensemble) |>
-  dplyr::summarise(diff_total_Mg = sum(diff_total_Mg), total_ha = sum(area_ha), .groups = "drop") |>
-  dplyr::mutate(diff_total_Tg = PEcAn.utils::ud_convert(diff_total_Mg, "Mg", "Tg"), diff_density_Mg_ha = diff_total_Mg / total_ha) |>
+  dplyr::summarise(diff_total = sum(diff_total), total_ha = sum(area_ha), .groups = "drop") |>
+  dplyr::mutate(diff_density_per_ha = diff_total / total_ha) |>
   dplyr::group_by(county, model_output) |>
-  dplyr::summarise(mean_diff_total_Tg = mean(diff_total_Tg), mean_diff_density_Mg_ha = mean(diff_density_Mg_ha), .groups = "drop") |>
+  dplyr::summarise(mean_diff_total = mean(diff_total), mean_diff_density_per_ha = mean(diff_density_per_ha), .groups = "drop") |>
   dplyr::right_join(county_boundaries, by = "county")
 
 for (pool in unique(stats::na.omit(diff_county$model_output))) {
   dat_pool <- dplyr::filter(diff_county, model_output == pool)
 
   # Density difference map (Mg/ha)
-  p_density <- ggplot2::ggplot(dat_pool, ggplot2::aes(geometry = geom, fill = mean_diff_density_Mg_ha)) +
+  p_density <- ggplot2::ggplot(dat_pool, ggplot2::aes(geometry = geom, fill = mean_diff_density_per_ha)) +
     ggplot2::geom_sf(data = county_boundaries, fill = "white", color = "black") +
     ggplot2::geom_sf() +
     ggplot2::scale_fill_gradient2(low = "royalblue", mid = "white", high = "firebrick", midpoint = 0, na.value = "white") +
     ggplot2::theme_minimal() +
     ggplot2::labs(
-      title = paste("Difference in Carbon Density (Mg/ha): (woody + annual) - (woody)", pool),
-      fill = "Delta (Mg/ha)"
+      title = paste("Difference in Density: (woody + annual) - (woody)", pool),
+      fill = "Delta (per ha)"
     )
   ggsave_optimized(
     filename = here::here("figures", paste0("county_diff_woody_plus_annual_minus_woody_", pool, "_carbon_density.webp")),
@@ -225,14 +225,14 @@ for (pool in unique(stats::na.omit(diff_county$model_output))) {
   )
 
   # Stock difference map (Tg)
-  p_stock <- ggplot2::ggplot(dat_pool, ggplot2::aes(geometry = geom, fill = mean_diff_total_Tg)) +
+  p_stock <- ggplot2::ggplot(dat_pool, ggplot2::aes(geometry = geom, fill = mean_diff_total)) +
     ggplot2::geom_sf(data = county_boundaries, fill = "white", color = "black") +
     ggplot2::geom_sf() +
     ggplot2::scale_fill_gradient2(low = "royalblue", mid = "white", high = "firebrick", midpoint = 0, na.value = "white") +
     ggplot2::theme_minimal() +
     ggplot2::labs(
-      title = paste("Difference in Carbon Stock (Tg): (woody + annual) - (woody)", pool),
-      fill = "Delta (Tg)"
+      title = paste("Difference in Total: (woody + annual) - (woody)", pool),
+      fill = "Delta (total)"
     )
   ggsave_optimized(
     filename = here::here("figures", paste0("county_diff_woody_plus_annual_minus_woody_", pool, "_carbon_stock.webp")),
@@ -250,8 +250,8 @@ if (file.exists(delta_csv)) {
       site_id = readr::col_character(),
       pft = readr::col_character(),
       ensemble = readr::col_double(),
-      delta_c_density_Mg_ha = readr::col_double(),
-      delta_total_c_Mg = readr::col_double(),
+      delta_density_per_ha = readr::col_double(),
+      delta_total = readr::col_double(),
       area_ha = readr::col_double(),
       county = readr::col_character(),
       model_output = readr::col_character()
@@ -260,15 +260,14 @@ if (file.exists(delta_csv)) {
 
   delta_county <- deltas |>
     dplyr::group_by(model_output, pft, county, ensemble) |>
-    dplyr::summarize(total_delta_Mg = sum(delta_total_c_Mg), total_ha = sum(area_ha), .groups = "drop") |>
+    dplyr::summarize(total_delta = sum(delta_total), total_ha = sum(area_ha), .groups = "drop") |>
     dplyr::mutate(
-      delta_density_Mg_ha = total_delta_Mg / total_ha,
-      delta_total_Tg = PEcAn.utils::ud_convert(total_delta_Mg, "Mg", "Tg")
+      delta_density_per_ha = total_delta / total_ha
     ) |>
     dplyr::group_by(model_output, pft, county) |>
     dplyr::summarize(
-      mean_delta_density_Mg_ha = mean(delta_density_Mg_ha),
-      mean_delta_total_Tg = mean(delta_total_Tg),
+      mean_delta_density_per_ha = mean(delta_density_per_ha),
+      mean_delta_total = mean(total_delta),
       .groups = "drop"
     ) |>
     dplyr::right_join(county_boundaries, by = "county")
@@ -283,7 +282,7 @@ if (file.exists(delta_csv)) {
       datp <- dplyr::filter(delta_county, pft == !!pft, model_output == !!model_output)
       pft_key <- stringr::str_replace_all(pft, "[^A-Za-z0-9]+", "_")
       # density
-      p_den <- ggplot2::ggplot(datp, ggplot2::aes(geometry = geom, fill = mean_delta_density_Mg_ha)) +
+      p_den <- ggplot2::ggplot(datp, ggplot2::aes(geometry = geom, fill = mean_delta_density_per_ha)) +
         ggplot2::geom_sf(data = county_boundaries, fill = "white", color = "black") +
         ggplot2::geom_sf() +
         ggplot2::scale_fill_gradient2(low = "royalblue", mid = "white", high = "firebrick", midpoint = 0, na.value = "white") +
@@ -297,7 +296,7 @@ if (file.exists(delta_csv)) {
         plot = p_den, width = 10, height = 5, units = "in", dpi = 96, bg = "white"
       )
       # stock
-      p_stk <- ggplot2::ggplot(datp, ggplot2::aes(geometry = geom, fill = mean_delta_total_Tg)) +
+      p_stk <- ggplot2::ggplot(datp, ggplot2::aes(geometry = geom, fill = mean_delta_total)) +
         ggplot2::geom_sf(data = county_boundaries, fill = "white", color = "black") +
         ggplot2::geom_sf() +
         ggplot2::scale_fill_gradient2(low = "royalblue", mid = "white", high = "firebrick", midpoint = 0, na.value = "white") +


### PR DESCRIPTION
Extends the downscaling pipeline to support N2O_flux and CH4_flux in addition to carbon pools (TotSoilCarb, AGB).

- add N2O_flux and CH4_flux to `outputs_to_extract` in config
- replace `logger.severe` with `logger.info` for flux variables in extraction (030)
- separate pool/flux handling in multi-PFT aggregation; fluxes bypass mixing (031)
- add `convert_to_reporting_units()` for variable unit conversion (040)
- rename carbon specific columns (`c_density_Mg_ha`, `total_c_Mg`, `total_c_Tg`) to generic names (`density_per_ha`, `total_per_field`, `total_per_county`) across downstream scripts (040–043)

**key things**
- flux variables (N2O, CH4) are per-PFT instantaneous rates; mixing gas emissions across overlapping PFTs is not physically meaningful, so fluxes pass through unchanged in 031
- pools convert kg/m2 -> Mg/ha via `ud_convert`; fluxes convert kg/m2/s -> kg/ha/yr via `rate × seconds_per_year × m2_per_ha`
- each variable gets its own random forest model (not multivariate)

implements [#183](https://github.com/ccmmf/organization/issues/183)