### PR TITLE
Add Salinas SOCS and Modesto Nichols to anchor_sites

### DIFF
--- a/data/anchor_sites.csv
+++ b/data/anchor_sites.csv
@@ -24,3 +24,5 @@ c3e9295555ef591a,38.11572,-121.64507,US-Tw3,Twitchell Alfalfa,Alfalfa,herbaceous
 242c6c0992817300,39.67869,-122.00275,US-RGO,Glenn County Organic Rice,Organic rice,herbaceous crop
 ec0e8b4d92044f52,38.54295,-121.87235,russell-ranch,Russell Ranch,"tomato, corn, wheat",herbaceous crop
 2ef544c85524ff53,36.34077,-120.10544,west-side,West Side Research Center,Row crops including cotton,herbaceous crop
+9f296becf416ce87,36.617,-121.533,salinas-socs,USDA-ARS Salinas SOCS,"lettuce, broccoli",herbaceous crop
+9cb08ca2174bede7,37.6273,-121.0893,modesto-nichols,Nichols 2024 Modesto Almond,Almond,woody perennial crop


### PR DESCRIPTION
Adds Salinas SOCS and Modesto Nichols 2024 to anchor_sites.csv for cal/val site setup (ccmmf/organization#236).